### PR TITLE
Allow mining reward notifications

### DIFF
--- a/components/notifications/notification-bell.tsx
+++ b/components/notifications/notification-bell.tsx
@@ -99,6 +99,8 @@ export function NotificationBell() {
         return "🎉"
       case "cap-reached":
         return "⚠️"
+      case "mining-reward":
+        return "⛏️"
       default:
         return "📢"
     }

--- a/models/Notification.ts
+++ b/models/Notification.ts
@@ -9,6 +9,7 @@ export interface INotification extends Document {
     | "level-up"
     | "cap-reached"
     | "team-reward-claimed"
+    | "mining-reward"
   title: string
   body: string
   read: boolean
@@ -27,6 +28,7 @@ const NotificationSchema = new Schema<INotification>(
         "level-up",
         "cap-reached",
         "team-reward-claimed",
+        "mining-reward",
       ],
       required: true,
     },


### PR DESCRIPTION
## Summary
- allow the Notification model to persist mining reward entries by adding the new kind to the schema and interface
- surface a dedicated icon in the notification bell for mining reward alerts so they appear with the correct glyph

## Testing
- node - <<'NODE' ... (validate Notification accepts mining-reward)


------
https://chatgpt.com/codex/tasks/task_e_68dedc57d1288327aedb3974493f35ca