### PR TITLE
Add withdrawal support to wallet page

### DIFF
--- a/app/wallet/actions.ts
+++ b/app/wallet/actions.ts
@@ -84,6 +84,17 @@ export async function submitDepositAction(_: DepositFormState, formData: FormDat
   }
 }
 
+function resolveInternalUrl(path: string): string {
+  const configuredBase =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXTAUTH_URL ||
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "")
+
+  const baseUrl = configuredBase ? configuredBase.replace(/\/$/, "") : "http://localhost:3000"
+
+  return `${baseUrl}${path.startsWith("/") ? path : `/${path}`}`
+}
+
 export async function submitWithdrawAction(_: WithdrawFormState, formData: FormData): Promise<WithdrawFormState> {
   const cookieStore = await cookies()
   const token = cookieStore.get("auth-token")?.value
@@ -112,7 +123,7 @@ export async function submitWithdrawAction(_: WithdrawFormState, formData: FormD
     .join("; ")
 
   try {
-    const response = await fetch("/api/wallet/withdraw", {
+    const response = await fetch(resolveInternalUrl("/api/wallet/withdraw"), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/app/wallet/actions.ts
+++ b/app/wallet/actions.ts
@@ -11,6 +11,11 @@ export interface DepositFormState {
   success?: string | null
 }
 
+export interface WithdrawFormState {
+  error?: string | null
+  success?: string | null
+}
+
 function isFileLike(value: unknown): value is File {
   if (!value || typeof value !== "object") {
     return false
@@ -76,5 +81,71 @@ export async function submitDepositAction(_: DepositFormState, formData: FormDat
 
     console.error("Deposit submission failed", error)
     return { error: "Unable to submit deposit. Please try again." }
+  }
+}
+
+export async function submitWithdrawAction(_: WithdrawFormState, formData: FormData): Promise<WithdrawFormState> {
+  const cookieStore = await cookies()
+  const token = cookieStore.get("auth-token")?.value
+  if (!token) {
+    return { error: "You must be signed in to submit a withdrawal." }
+  }
+
+  const user = verifyToken(token)
+  if (!user) {
+    return { error: "Session expired. Please sign in again." }
+  }
+
+  const amountValue = Number.parseFloat(String(formData.get("amount") ?? ""))
+  if (!Number.isFinite(amountValue) || amountValue <= 0) {
+    return { error: "Enter a valid withdrawal amount" }
+  }
+
+  const walletAddress = String(formData.get("walletAddress") ?? "").trim()
+  if (!walletAddress) {
+    return { error: "Enter or select a wallet address" }
+  }
+
+  const cookieHeader = cookieStore
+    .getAll()
+    .map((cookie) => `${cookie.name}=${cookie.value}`)
+    .join("; ")
+
+  try {
+    const response = await fetch("/api/wallet/withdraw", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(cookieHeader ? { Cookie: cookieHeader } : {}),
+      },
+      body: JSON.stringify({
+        amount: amountValue,
+        walletAddress,
+      }),
+      cache: "no-store",
+    })
+
+    const data = await response.json().catch(() => null)
+
+    if (!response.ok) {
+      const message =
+        data?.error ||
+        (Array.isArray(data?.details) && data.details.length > 0 && data.details[0]?.message) ||
+        "Withdrawal request failed. Please try again."
+
+      return { error: message }
+    }
+
+    revalidatePath("/wallet")
+
+    return {
+      success:
+        typeof data?.transaction?.amount === "number"
+          ? `Withdrawal request for $${Number(data.transaction.amount).toFixed(2)} submitted successfully.`
+          : "Withdrawal request submitted successfully.",
+    }
+  } catch (error) {
+    console.error("Withdrawal submission failed", error)
+    return { error: "Unable to submit withdrawal. Please try again." }
   }
 }

--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -5,8 +5,9 @@ import { verifyToken } from "@/lib/auth"
 import { fetchWalletContext } from "@/lib/services/wallet"
 import { getDepositWalletOptions } from "@/lib/config/wallet"
 import { Sidebar } from "@/components/layout/sidebar"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { DepositForm } from "@/components/wallet/deposit-form"
+import { WithdrawForm } from "@/components/wallet/withdraw-form"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Wallet, ArrowUpRight, ArrowDownLeft } from "lucide-react"
 
@@ -87,15 +88,49 @@ export default async function WalletPage() {
             </Card>
           </section>
 
-          {walletOptions.length === 0 ? (
-            <Alert variant="destructive">
-              <AlertDescription>
-                Deposit wallets are not configured. Please contact support.
-              </AlertDescription>
-            </Alert>
-          ) : (
-            <DepositForm options={walletOptions} minDeposit={context.minDeposit} />
-          )}
+          <section className="grid gap-6 xl:grid-cols-2">
+            <Card className="h-full">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  <ArrowDownLeft className="h-5 w-5 text-emerald-500" />
+                  Deposit USDT
+                </CardTitle>
+                <CardDescription>
+                  Transfer funds to one of the approved wallets and submit your receipt for review.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="pb-6">
+                {walletOptions.length === 0 ? (
+                  <Alert variant="destructive">
+                    <AlertDescription>
+                      Deposit wallets are not configured. Please contact support.
+                    </AlertDescription>
+                  </Alert>
+                ) : (
+                  <DepositForm options={walletOptions} minDeposit={context.minDeposit} />
+                )}
+              </CardContent>
+            </Card>
+
+            <Card className="h-full">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  <ArrowUpRight className="h-5 w-5 text-sky-500" />
+                  Withdraw Funds
+                </CardTitle>
+                <CardDescription>
+                  Request a withdrawal to a saved wallet or provide a new USDT address.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="pb-6">
+                <WithdrawForm
+                  minWithdraw={context.withdrawConfig.minWithdraw}
+                  currentBalance={context.stats.currentBalance}
+                  pendingWithdraw={context.stats.pendingWithdraw}
+                />
+              </CardContent>
+            </Card>
+          </section>
         </div>
       </main>
     </div>

--- a/components/admin/transaction-table.tsx
+++ b/components/admin/transaction-table.tsx
@@ -20,12 +20,17 @@ import { Loader2, Check, X, Eye } from "lucide-react"
 
 interface Transaction {
   _id: string
-  userId: {
-    _id: string
-    name: string
-    email: string
-    referralCode: string
-  }
+  userId:
+    | {
+        _id: string
+        name?: string
+        email?: string
+        referralCode?: string
+        toString?: () => string
+      }
+    | string
+    | null
+    | undefined
   type: string
   amount: number
   status: string
@@ -58,6 +63,13 @@ export function TransactionTable({ transactions, onRefresh }: TransactionTablePr
     selectedTransaction?.type === "deposit" && selectedTransaction.meta?.receipt
       ? (selectedTransaction.meta.receipt as ReceiptMeta)
       : null
+
+  const selectedUser =
+    selectedTransaction && typeof selectedTransaction.userId === "object"
+      ? selectedTransaction.userId
+      : null
+
+  const selectedAmount = selectedTransaction ? Number(selectedTransaction.amount) : Number.NaN
 
   const handleApprove = async (transaction: Transaction) => {
     setLoading(true)
@@ -171,52 +183,77 @@ export function TransactionTable({ transactions, onRefresh }: TransactionTablePr
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {transactions.map((transaction) => (
-                  <TableRow key={transaction._id}>
-                    <TableCell>
-                      <div>
-                        <div className="font-medium">{transaction.userId.name}</div>
-                        <div className="text-sm text-muted-foreground">{transaction.userId.email}</div>
-                        <div className="text-xs font-mono">{transaction.userId.referralCode}</div>
-                      </div>
-                    </TableCell>
-                    <TableCell>{getTypeBadge(transaction.type)}</TableCell>
-                    <TableCell className="font-mono">${transaction.amount.toFixed(2)}</TableCell>
-                    <TableCell>{getStatusBadge(transaction.status)}</TableCell>
-                    <TableCell>{new Date(transaction.createdAt).toLocaleDateString()}</TableCell>
-                    <TableCell>
-                      <div className="flex items-center space-x-2">
-                        <Button variant="ghost" size="sm" onClick={() => setSelectedTransaction(transaction)}>
-                          <Eye className="h-4 w-4" />
-                        </Button>
-                        {transaction.status === "pending" && (
-                          <>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => handleApprove(transaction)}
-                              disabled={loading}
-                              className="text-green-600 hover:text-green-700"
-                            >
-                              {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => {
-                                setSelectedTransaction(transaction)
-                                setShowRejectDialog(true)
-                              }}
-                              disabled={loading}
-                              className="text-red-600 hover:text-red-700"
-                            >
-                              <X className="h-4 w-4" />
-                            </Button>
-                          </>
-                        )}
-                      </div>
-                    </TableCell>
-                  </TableRow>
+                {transactions.map((transaction) => {
+                  const userRecord =
+                    transaction.userId && typeof transaction.userId === "object"
+                      ? transaction.userId
+                      : null
+
+                  const amountValue = Number(transaction.amount)
+                  const createdAt = transaction.createdAt ? new Date(transaction.createdAt) : null
+                  const fallbackIdentifier =
+                    userRecord?._id || (typeof transaction.userId === "string" ? transaction.userId : undefined)
+                  const isPending = transaction.status === "pending"
+
+                  return (
+                    <TableRow key={transaction._id}>
+                      <TableCell>
+                        <div>
+                          <div className="font-medium">
+                            {userRecord?.name || "Deleted user"}
+                          </div>
+                          <div className="text-sm text-muted-foreground">
+                            {userRecord?.email || "User record unavailable"}
+                          </div>
+                          <div className="text-xs font-mono">
+                            {userRecord?.referralCode || fallbackIdentifier || "—"}
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell>{getTypeBadge(transaction.type)}</TableCell>
+                      <TableCell className="font-mono">
+                        {Number.isFinite(amountValue) ? `$${amountValue.toFixed(2)}` : "—"}
+                      </TableCell>
+                      <TableCell>{getStatusBadge(transaction.status)}</TableCell>
+                      <TableCell>
+                        {createdAt && !Number.isNaN(createdAt.getTime())
+                          ? createdAt.toLocaleDateString()
+                          : "—"}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center space-x-2">
+                          <Button variant="ghost" size="sm" onClick={() => setSelectedTransaction(transaction)}>
+                            <Eye className="h-4 w-4" />
+                          </Button>
+                          {isPending && (
+                            <>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => handleApprove(transaction)}
+                                disabled={loading}
+                                className="text-green-600 hover:text-green-700"
+                              >
+                                {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => {
+                                  setSelectedTransaction(transaction)
+                                  setShowRejectDialog(true)
+                                }}
+                                disabled={loading}
+                                className="text-red-600 hover:text-red-700"
+                              >
+                                <X className="h-4 w-4" />
+                              </Button>
+                            </>
+                          )}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  )
                 ))}
               </TableBody>
             </Table>
@@ -235,8 +272,10 @@ export function TransactionTable({ transactions, onRefresh }: TransactionTablePr
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <Label>User</Label>
-                  <p className="text-sm">{selectedTransaction.userId.name}</p>
-                  <p className="text-xs text-muted-foreground">{selectedTransaction.userId.email}</p>
+                  <p className="text-sm">{selectedUser?.name || "Deleted user"}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {selectedUser?.email || "User record unavailable"}
+                  </p>
                 </div>
                 <div>
                   <Label>Type</Label>
@@ -244,7 +283,9 @@ export function TransactionTable({ transactions, onRefresh }: TransactionTablePr
                 </div>
                 <div>
                   <Label>Amount</Label>
-                  <p className="text-sm font-mono">${selectedTransaction.amount.toFixed(2)}</p>
+                  <p className="text-sm font-mono">
+                    {Number.isFinite(selectedAmount) ? `$${selectedAmount.toFixed(2)}` : "—"}
+                  </p>
                 </div>
                 <div>
                   <Label>Status</Label>

--- a/components/admin/transaction-table.tsx
+++ b/components/admin/transaction-table.tsx
@@ -254,7 +254,7 @@ export function TransactionTable({ transactions, onRefresh }: TransactionTablePr
                       </TableCell>
                     </TableRow>
                   )
-                ))}
+                })}
               </TableBody>
             </Table>
           </div>

--- a/components/wallet/withdraw-form.tsx
+++ b/components/wallet/withdraw-form.tsx
@@ -1,0 +1,271 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { useFormState, useFormStatus } from "react-dom"
+
+import { submitWithdrawAction, type WithdrawFormState } from "@/app/wallet/actions"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { ArrowUpRight, CheckCircle, Loader2 } from "lucide-react"
+
+interface WalletAddressOption {
+  id: string
+  label: string
+  chain: string
+  address: string
+  verified: boolean
+}
+
+interface WithdrawFormProps {
+  minWithdraw: number
+  currentBalance: number
+  pendingWithdraw: number
+}
+
+const initialState: WithdrawFormState = { error: null, success: null }
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+
+  return (
+    <Button
+      type="submit"
+      disabled={pending}
+      className="w-full h-12 rounded-xl bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 text-base font-semibold shadow-lg hover:from-blue-600 hover:to-purple-600"
+    >
+      {pending ? (
+        <>
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          Submitting...
+        </>
+      ) : (
+        <>
+          <ArrowUpRight className="mr-2 h-4 w-4" />
+          Submit Withdrawal Request
+        </>
+      )}
+    </Button>
+  )
+}
+
+export function WithdrawForm({ minWithdraw, currentBalance, pendingWithdraw }: WithdrawFormProps) {
+  const [state, formAction] = useFormState(submitWithdrawAction, initialState)
+
+  const [amount, setAmount] = useState("")
+  const [manualAddress, setManualAddress] = useState("")
+  const [addressMode, setAddressMode] = useState<"saved" | "manual">("manual")
+  const [addresses, setAddresses] = useState<WalletAddressOption[]>([])
+  const [addressesLoaded, setAddressesLoaded] = useState(false)
+  const [selectedAddressId, setSelectedAddressId] = useState("")
+  const [isLoadingAddresses, setIsLoadingAddresses] = useState(true)
+  const [addressError, setAddressError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+
+    async function loadAddresses() {
+      setIsLoadingAddresses(true)
+      try {
+        const response = await fetch("/api/e-wallet/addresses", {
+          method: "GET",
+          credentials: "include",
+          cache: "no-store",
+        })
+
+        const data = await response.json().catch(() => null)
+
+        if (!active) return
+
+        if (!response.ok) {
+          setAddressError(data?.error ?? "Unable to load saved addresses.")
+          setAddresses([])
+        } else {
+          const loadedAddresses = Array.isArray(data?.addresses)
+            ? (data.addresses as any[]).map((item) => ({
+                id: String(item._id ?? item.id ?? ""),
+                label: String(item.label ?? "Unnamed"),
+                chain: String(item.chain ?? ""),
+                address: String(item.address ?? ""),
+                verified: Boolean(item.verified ?? false),
+              }))
+            : []
+
+          setAddresses(loadedAddresses.filter((address) => address.address.length > 0))
+          setAddressError(null)
+        }
+      } catch (error) {
+        console.error("Failed to fetch saved addresses", error)
+        if (!active) return
+        setAddressError("Unable to load saved addresses.")
+        setAddresses([])
+      } finally {
+        if (active) {
+          setIsLoadingAddresses(false)
+          setAddressesLoaded(true)
+        }
+      }
+    }
+
+    loadAddresses()
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  useEffect(() => {
+    if (addresses.length > 0) {
+      setSelectedAddressId((previous) => previous || addresses[0].id)
+    } else {
+      setSelectedAddressId("")
+    }
+  }, [addresses])
+
+  useEffect(() => {
+    if (!addressesLoaded) {
+      return
+    }
+
+    if (addresses.length === 0) {
+      setAddressMode("manual")
+      return
+    }
+
+    setAddressMode((previous) => {
+      if (previous === "manual" && manualAddress.length === 0) {
+        return "saved"
+      }
+      return previous
+    })
+  }, [addresses, addressesLoaded, manualAddress])
+
+  useEffect(() => {
+    if (state?.success) {
+      setAmount("")
+      setManualAddress("")
+    }
+  }, [state?.success])
+
+  const selectedAddress = useMemo(
+    () => addresses.find((address) => address.id === selectedAddressId) ?? null,
+    [addresses, selectedAddressId],
+  )
+
+  return (
+    <form action={formAction} className="space-y-6">
+      {state?.error && (
+        <Alert variant="destructive">
+          <AlertDescription>{state.error}</AlertDescription>
+        </Alert>
+      )}
+
+      {state?.success && (
+        <Alert className="border-green-200 bg-green-50">
+          <div className="flex items-center gap-2 text-green-700">
+            <CheckCircle className="h-4 w-4" />
+            <AlertDescription>{state.success}</AlertDescription>
+          </div>
+        </Alert>
+      )}
+
+      <div className="rounded-2xl border border-slate-200 bg-muted/20 p-4 text-sm text-muted-foreground dark:border-slate-700 dark:bg-slate-900/40">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <span>Available balance: <strong className="text-foreground">${currentBalance.toFixed(2)}</strong></span>
+          <span>Pending approval: <strong className="text-foreground">${pendingWithdraw.toFixed(2)}</strong></span>
+        </div>
+        <p className="mt-2 text-xs">Minimum withdrawal: ${minWithdraw.toFixed(2)} USDT</p>
+      </div>
+
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="withdraw-amount">Amount (USDT)</Label>
+          <Input
+            id="withdraw-amount"
+            name="amount"
+            type="number"
+            inputMode="decimal"
+            min={minWithdraw}
+            step="0.01"
+            required
+            value={amount}
+            onChange={(event) => setAmount(event.target.value)}
+            placeholder={`Enter at least $${minWithdraw.toFixed(2)}`}
+          />
+          <p className="text-xs text-muted-foreground">
+            Withdraw at least ${minWithdraw.toFixed(2)} and no more than your available balance.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <Label>Destination wallet</Label>
+          <Tabs value={addressMode} onValueChange={(value) => setAddressMode(value as "saved" | "manual")}>
+            <TabsList>
+              <TabsTrigger value="saved" disabled={addresses.length === 0}>
+                Saved addresses
+              </TabsTrigger>
+              <TabsTrigger value="manual">New address</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="saved" className="mt-3 space-y-3">
+              {isLoadingAddresses ? (
+                <p className="text-sm text-muted-foreground">Loading saved addresses…</p>
+              ) : addresses.length === 0 ? (
+                <p className="text-sm text-muted-foreground">You have no saved addresses yet.</p>
+              ) : (
+                <>
+                  <Select value={selectedAddressId} onValueChange={setSelectedAddressId}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select a saved address" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {addresses.map((address) => (
+                        <SelectItem key={address.id} value={address.id}>
+                          {address.label} · {address.chain}
+                          {address.verified ? " ✅" : ""}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+
+                  {selectedAddress ? (
+                    <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-3 font-mono text-xs text-slate-700 dark:border-slate-600 dark:bg-slate-900/60 dark:text-slate-200">
+                      {selectedAddress.address}
+                    </div>
+                  ) : null}
+                </>
+              )}
+
+              {addressMode === "saved" && selectedAddress ? (
+                <input type="hidden" name="walletAddress" value={selectedAddress.address} />
+              ) : null}
+            </TabsContent>
+
+            <TabsContent value="manual" className="mt-3 space-y-2">
+              <Input
+                name="walletAddress"
+                value={manualAddress}
+                onChange={(event) => setManualAddress(event.target.value)}
+                placeholder="Enter the USDT wallet address"
+                autoComplete="off"
+                required={addressMode === "manual"}
+              />
+              <p className="text-xs text-muted-foreground">
+                Double-check the address network. Withdrawals sent to the wrong chain cannot be recovered.
+              </p>
+            </TabsContent>
+          </Tabs>
+
+          {addressError && <p className="text-xs text-destructive">{addressError}</p>}
+        </div>
+      </div>
+
+      <SubmitButton />
+    </form>
+  )
+}
+
+export default WithdrawForm

--- a/lib/services/wallet.ts
+++ b/lib/services/wallet.ts
@@ -18,6 +18,9 @@ export interface WalletContext {
     staked: number
   }
   minDeposit: number
+  withdrawConfig: {
+    minWithdraw: number
+  }
 }
 
 export async function fetchWalletContext(userId: string): Promise<WalletContext | null> {
@@ -40,6 +43,9 @@ export async function fetchWalletContext(userId: string): Promise<WalletContext 
   }
 
   const minDeposit = Number(settingsDoc?.gating?.minDeposit ?? 30)
+  const withdrawConfig = {
+    minWithdraw: Number(settingsDoc?.gating?.minWithdraw ?? 30),
+  }
 
   return {
     user: {
@@ -50,5 +56,6 @@ export async function fetchWalletContext(userId: string): Promise<WalletContext 
     },
     stats,
     minDeposit,
+    withdrawConfig,
   }
 }


### PR DESCRIPTION
## Summary
- extend the wallet context to expose withdrawal configuration such as the minimum withdrawal amount
- add a withdrawal server action that validates input, calls the internal API, and revalidates the wallet view
- introduce a client withdraw form that surfaces saved addresses and render it next to the existing deposit form

## Testing
- npm run lint *(fails: command prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68df22d573ac8327941130126cb632a9