### PR TITLE
Fix withdrawal notification validation

### DIFF
--- a/components/notifications/notification-bell.tsx
+++ b/components/notifications/notification-bell.tsx
@@ -95,6 +95,10 @@ export function NotificationBell() {
         return "💰"
       case "withdraw-approved":
         return "💸"
+      case "withdraw-requested":
+        return "📝"
+      case "withdraw-cancelled":
+        return "↩️"
       case "level-up":
         return "🎉"
       case "cap-reached":

--- a/models/Notification.ts
+++ b/models/Notification.ts
@@ -6,6 +6,8 @@ export interface INotification extends Document {
     | "referral-joined"
     | "deposit-approved"
     | "withdraw-approved"
+    | "withdraw-requested"
+    | "withdraw-cancelled"
     | "level-up"
     | "cap-reached"
     | "team-reward-claimed"
@@ -25,6 +27,8 @@ const NotificationSchema = new Schema<INotification>(
         "referral-joined",
         "deposit-approved",
         "withdraw-approved",
+        "withdraw-requested",
+        "withdraw-cancelled",
         "level-up",
         "cap-reached",
         "team-reward-claimed",


### PR DESCRIPTION
## Summary
- allow withdrawal request and cancellation notifications in the schema to prevent validation failures
- add icons for the new withdrawal notification types in the notification bell

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df43e7bac08327bfc7a022967e0d5a