### PR TITLE
Add theme toggle and refresh dark-mode styling

### DIFF
--- a/app/auth/forgot/page.tsx
+++ b/app/auth/forgot/page.tsx
@@ -73,16 +73,16 @@ export default function ForgotPasswordPage() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-100 flex items-center justify-center p-4">
-      <div className="w-full max-w-lg rounded-2xl overflow-hidden shadow-xl border border-slate-200 bg-white">
-        <div className="bg-black text-white text-center py-4">
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-[hsl(var(--background))] via-[hsl(var(--secondary))] to-[hsl(var(--muted))] p-4 text-foreground transition-colors dark:from-[#050505] dark:via-[#0a0a0a] dark:to-[#141414]">
+      <div className="w-full max-w-lg overflow-hidden rounded-3xl border border-border/70 bg-card shadow-xl shadow-primary/10 transition-colors">
+        <div className="bg-gradient-to-r from-primary to-accent py-4 text-center text-primary-foreground">
           <h1 className="text-lg font-semibold tracking-wide">Reset Your Password</h1>
         </div>
 
-        <div className="px-8 py-6 space-y-6">
+        <div className="space-y-6 px-6 py-6 sm:px-8">
           <div className="flex justify-center">
-            <div className="w-14 h-14 rounded-full border border-slate-300 flex items-center justify-center text-slate-600">
-              <LockKeyhole className="w-8 h-8" />
+            <div className="flex h-14 w-14 items-center justify-center rounded-full border border-border/60 bg-background/80 text-primary shadow-sm">
+              <LockKeyhole className="h-8 w-8" />
             </div>
           </div>
 
@@ -102,7 +102,7 @@ export default function ForgotPasswordPage() {
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="email" className="text-sm font-semibold text-slate-700">
+              <Label htmlFor="email" className="text-sm font-semibold text-foreground/90">
                 Email
               </Label>
               <Input
@@ -112,12 +112,12 @@ export default function ForgotPasswordPage() {
                 value={formData.email}
                 onChange={(event) => setFormData((prev) => ({ ...prev, email: event.target.value }))}
                 required
-                className="h-11 rounded-md border-slate-300 bg-slate-50 text-slate-700 placeholder:text-slate-400"
+                className="h-11"
               />
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="password" className="text-sm font-semibold text-slate-700">
+              <Label htmlFor="password" className="text-sm font-semibold text-foreground/90">
                 New Password
               </Label>
               <Input
@@ -128,12 +128,12 @@ export default function ForgotPasswordPage() {
                 onChange={(event) => setFormData((prev) => ({ ...prev, password: event.target.value }))}
                 required
                 minLength={6}
-                className="h-11 rounded-md border-slate-300 bg-slate-50 text-slate-700 placeholder:text-slate-400"
+                className="h-11"
               />
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="confirmPassword" className="text-sm font-semibold text-slate-700">
+              <Label htmlFor="confirmPassword" className="text-sm font-semibold text-foreground/90">
                 Confirm Password
               </Label>
               <Input
@@ -146,21 +146,16 @@ export default function ForgotPasswordPage() {
                 }
                 required
                 minLength={6}
-                className="h-11 rounded-md border-slate-300 bg-slate-50 text-slate-700 placeholder:text-slate-400"
+                className="h-11"
               />
             </div>
 
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-              <Button
-                type="button"
-                variant="outline"
-                className="sm:w-auto h-11 border-black text-black hover:bg-black/10"
-                onClick={() => router.push("/auth/login")}
-              >
+              <Button type="button" variant="outline" className="h-11 sm:w-auto" onClick={() => router.push("/auth/login")}>
                 Back to Login
               </Button>
 
-              <Button type="submit" className="h-11 flex-1 sm:flex-none bg-black hover:bg-black/90" disabled={isLoading}>
+              <Button type="submit" className="h-11 flex-1 sm:flex-none shadow-lg shadow-primary/20" disabled={isLoading}>
                 {isLoading ? (
                   <>
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -173,9 +168,9 @@ export default function ForgotPasswordPage() {
             </div>
           </form>
 
-          <p className="text-center text-sm text-slate-600">
+          <p className="text-center text-sm text-muted-foreground">
             Remembered your password?{" "}
-            <Link href="/auth/login" className="font-semibold text-black hover:underline">
+            <Link href="/auth/login" className="font-semibold text-primary hover:underline">
               Login here
             </Link>
           </p>

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -2,7 +2,7 @@ import { LoginForm } from "@/components/auth/login-form"
 
 export default function LoginPage() {
   return (
-    <div className="min-h-screen bg-slate-100 flex items-center justify-center p-4 sm:p-6">
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-[hsl(var(--background))] via-[hsl(var(--secondary))] to-[hsl(var(--muted))] p-4 text-foreground transition-colors dark:from-[#050505] dark:via-[#0a0a0a] dark:to-[#141414] sm:p-6">
       <LoginForm />
     </div>
   )

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -3,7 +3,7 @@ import { RegisterForm } from "@/components/auth/register-form"
 
 export default function RegisterPage() {
   return (
-    <div className="min-h-screen bg-slate-100 flex items-center justify-center p-4 sm:p-6">
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-[hsl(var(--background))] via-[hsl(var(--secondary))] to-[hsl(var(--muted))] p-4 text-foreground transition-colors dark:from-[#050505] dark:via-[#0a0a0a] dark:to-[#141414] sm:p-6">
       <Suspense fallback={<div className="text-sm text-muted-foreground">Preparing form...</div>}>
         <RegisterForm />
       </Suspense>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,10 @@
 import type React from "react"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
+
+import { ThemeProvider } from "@/components/theme-provider"
+import { cn } from "@/lib/utils"
+
 import "./globals.css"
 
 const inter = Inter({ subsets: ["latin"] })
@@ -18,8 +22,12 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
-      <body className={inter.className}>{children}</body>
+    <html lang="en" suppressHydrationWarning>
+      <body className={cn("min-h-screen bg-background font-sans antialiased text-foreground", inter.className)}>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
+          {children}
+        </ThemeProvider>
+      </body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,20 +5,20 @@ import Image from "next/image"
 
 export default function HomePage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-stone-50 to-amber-100">
+    <div className="min-h-screen bg-gradient-to-br from-[hsl(var(--background))] via-[hsl(var(--secondary))] to-[hsl(var(--muted))] text-foreground transition-colors dark:from-[#050505] dark:via-[#0c0c0c] dark:to-[#161616]">
       {/* Header */}
-      <header className="border-b bg-white/80 backdrop-blur-sm">
-        <div className="container mx-auto px-4 py-4 flex items-center justify-between">
+      <header className="border-b border-border/60 bg-card/80 backdrop-blur-md supports-[backdrop-filter]:bg-card/60 dark:bg-[#101010]/80">
+        <div className="container mx-auto flex items-center justify-between px-4 py-4">
           <div className="flex items-center space-x-2">
             <Image src="/images/logo.png" alt="Mintmine Pro" width={32} height={32} className="rounded-lg" />
             <span className="text-xl font-bold">Mintmine Pro</span>
           </div>
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center space-x-3">
             <Link href="/auth/login">
               <Button variant="ghost">Sign In</Button>
             </Link>
             <Link href="/auth/register">
-              <Button>Get Started</Button>
+              <Button className="shadow-lg shadow-primary/20">Get Started</Button>
             </Link>
           </div>
         </div>
@@ -26,28 +26,28 @@ export default function HomePage() {
 
       {/* Hero Section */}
       <main className="container mx-auto px-4 py-16">
-        <div className="text-center max-w-4xl mx-auto">
-          <h1 className="text-5xl font-bold text-balance mb-6">
+        <div className="mx-auto max-w-4xl text-center">
+          <h1 className="text-balance text-5xl font-bold leading-tight sm:text-6xl">
             Next-Generation
-            <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-500 to-amber-700">
+            <span className="bg-gradient-to-r from-primary via-accent to-primary/80 bg-clip-text text-transparent">
               {" "}
               Crypto Mining{" "}
             </span>
             Platform
           </h1>
-          <p className="text-xl text-muted-foreground text-balance mb-8">
+          <p className="mt-6 text-balance text-lg text-muted-foreground sm:text-xl">
             Join our innovative mining ecosystem with referral rewards, team building, and sustainable earning
             opportunities.
           </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <div className="mt-8 flex flex-col justify-center gap-4 sm:flex-row">
             <Link href="/auth/register">
-              <Button size="lg" className="text-lg px-8">
+              <Button size="lg" className="px-8 text-lg shadow-lg shadow-primary/25">
                 Start Mining Today
                 <ArrowRight className="ml-2 h-5 w-5" />
               </Button>
             </Link>
             <Link href="/auth/login">
-              <Button size="lg" variant="outline" className="text-lg px-8 bg-transparent">
+              <Button size="lg" variant="outline" className="px-8 text-lg">
                 Sign In
               </Button>
             </Link>
@@ -55,31 +55,31 @@ export default function HomePage() {
         </div>
 
         {/* Features */}
-        <div className="grid md:grid-cols-3 gap-8 mt-20">
-          <div className="text-center p-6">
-            <div className="w-16 h-16 bg-gradient-to-br from-amber-400 to-amber-600 rounded-2xl flex items-center justify-center mx-auto mb-4">
-              <Zap className="w-8 h-8 text-white" />
+        <div className="mt-20 grid gap-8 md:grid-cols-3">
+          <div className="group rounded-3xl border border-border/60 bg-card/80 p-6 shadow-lg shadow-primary/10 transition-all hover:-translate-y-1 hover:border-primary/60 hover:shadow-primary/30">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-accent text-primary-foreground shadow-lg shadow-primary/30">
+              <Zap className="h-8 w-8" />
             </div>
-            <h3 className="text-xl font-semibold mb-2">Easy Mining</h3>
-            <p className="text-muted-foreground">
+            <h3 className="text-xl font-semibold">Easy Mining</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
               Simple one-click mining with daily rewards and automated profit distribution.
             </p>
           </div>
-          <div className="text-center p-6">
-            <div className="w-16 h-16 bg-gradient-to-br from-amber-400 to-amber-600 rounded-2xl flex items-center justify-center mx-auto mb-4">
-              <Users className="w-8 h-8 text-white" />
+          <div className="group rounded-3xl border border-border/60 bg-card/80 p-6 shadow-lg shadow-primary/10 transition-all hover:-translate-y-1 hover:border-primary/60 hover:shadow-primary/30">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-accent text-primary-foreground shadow-lg shadow-primary/30">
+              <Users className="h-8 w-8" />
             </div>
-            <h3 className="text-xl font-semibold mb-2">Team Building</h3>
-            <p className="text-muted-foreground">
+            <h3 className="text-xl font-semibold">Team Building</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
               Build your network with referral rewards and multi-level commission structure.
             </p>
           </div>
-          <div className="text-center p-6">
-            <div className="w-16 h-16 bg-gradient-to-br from-amber-400 to-amber-600 rounded-2xl flex items-center justify-center mx-auto mb-4">
-              <Shield className="w-8 h-8 text-white" />
+          <div className="group rounded-3xl border border-border/60 bg-card/80 p-6 shadow-lg shadow-primary/10 transition-all hover:-translate-y-1 hover:border-primary/60 hover:shadow-primary/30">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-accent text-primary-foreground shadow-lg shadow-primary/30">
+              <Shield className="h-8 w-8" />
             </div>
-            <h3 className="text-xl font-semibold mb-2">Secure Platform</h3>
-            <p className="text-muted-foreground">
+            <h3 className="text-xl font-semibold">Secure Platform</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
               Advanced security measures with transparent transaction tracking and admin oversight.
             </p>
           </div>

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -94,15 +94,15 @@ export function LoginForm() {
   }
 
   return (
-    <div className="w-full max-w-lg rounded-2xl overflow-hidden shadow-xl border border-slate-200 bg-white">
-      <div className="bg-black text-white text-center py-4">
+    <div className="w-full max-w-lg overflow-hidden rounded-3xl border border-border/70 bg-card shadow-xl shadow-primary/10 transition-colors">
+      <div className="bg-gradient-to-r from-primary to-accent py-4 text-center text-primary-foreground">
         <h1 className="text-lg font-semibold tracking-wide">User Referral Login System</h1>
       </div>
 
-      <div className="px-6 sm:px-8 py-6 space-y-6">
+      <div className="space-y-6 px-6 py-6 sm:px-8">
         <div className="flex justify-center">
-          <div className="w-14 h-14 rounded-full border border-slate-300 flex items-center justify-center text-slate-600">
-            <UserRoundPlus className="w-8 h-8" />
+          <div className="flex h-14 w-14 items-center justify-center rounded-full border border-border/60 bg-background/80 text-primary shadow-sm">
+            <UserRoundPlus className="h-8 w-8" />
           </div>
         </div>
 
@@ -127,7 +127,7 @@ export function LoginForm() {
             </TabsList>
 
             <TabsContent value="email" className="space-y-2">
-              <Label htmlFor="email" className="text-sm font-semibold text-slate-700">
+              <Label htmlFor="email" className="text-sm font-semibold text-foreground/90">
                 Email Address
               </Label>
               <Input
@@ -136,12 +136,12 @@ export function LoginForm() {
                 placeholder="Enter your email"
                 value={formData.email}
                 onChange={(event) => setFormData((prev) => ({ ...prev, email: event.target.value }))}
-                className="h-11 rounded-md border-slate-300 bg-slate-50 text-slate-700 placeholder:text-slate-400"
+                className="h-11"
               />
             </TabsContent>
 
             <TabsContent value="phone" className="space-y-2">
-              <Label htmlFor="phone" className="text-sm font-semibold text-slate-700">
+              <Label htmlFor="phone" className="text-sm font-semibold text-foreground/90">
                 Phone Number
               </Label>
               <div className="flex flex-col sm:flex-row sm:items-center gap-2">
@@ -149,7 +149,7 @@ export function LoginForm() {
                   value={formData.countryCode}
                   onValueChange={(value) => setFormData((prev) => ({ ...prev, countryCode: value }))}
                 >
-                  <SelectTrigger className="sm:w-40 h-11 rounded-md border-slate-300 bg-slate-50 text-slate-700">
+                  <SelectTrigger className="h-11 rounded-md sm:w-40">
                     <SelectValue placeholder="Country" />
                   </SelectTrigger>
                   <SelectContent className="max-h-64">
@@ -168,7 +168,7 @@ export function LoginForm() {
                   onChange={(event) =>
                     setFormData((prev) => ({ ...prev, phone: event.target.value.replace(/[^\d]/g, "") }))
                   }
-                  className="h-11 flex-1 rounded-md border-slate-300 bg-slate-50 text-slate-700 placeholder:text-slate-400"
+                  className="h-11 flex-1"
                 />
               </div>
               <p className="text-xs text-muted-foreground">
@@ -178,7 +178,7 @@ export function LoginForm() {
           </Tabs>
 
           <div className="space-y-2">
-            <Label htmlFor="password" className="text-sm font-semibold text-slate-700">
+            <Label htmlFor="password" className="text-sm font-semibold text-foreground/90">
               Password
             </Label>
             <Input
@@ -188,26 +188,24 @@ export function LoginForm() {
               value={formData.password}
               onChange={(event) => setFormData((prev) => ({ ...prev, password: event.target.value }))}
               required
-              className="h-11 rounded-md border-slate-300 bg-slate-50 text-slate-700 placeholder:text-slate-400"
+              className="h-11"
             />
           </div>
 
           <div className="flex items-center justify-end text-sm">
-            <Link href="/auth/forgot" className="text-slate-600 hover:text-black font-medium underline-offset-4 hover:underline">
+            <Link
+              href="/auth/forgot"
+              className="font-medium text-primary underline-offset-4 transition-colors hover:text-primary/80 hover:underline"
+            >
               Forgot Password?
             </Link>
           </div>
 
           <div className="flex flex-col sm:flex-row gap-3">
-            <Button
-              type="button"
-              variant="outline"
-              className="flex-1 h-11 border-black text-black hover:bg-black/10"
-              onClick={() => router.push("/auth/register")}
-            >
+            <Button type="button" variant="outline" className="flex-1 h-11" onClick={() => router.push("/auth/register")}>
               (Create Account)
             </Button>
-            <Button type="submit" className="flex-1 h-11 bg-black hover:bg-black/90" disabled={isLoading}>
+            <Button type="submit" className="flex-1 h-11 shadow-lg shadow-primary/20" disabled={isLoading}>
               {isLoading ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/components/auth/register-form.tsx
+++ b/components/auth/register-form.tsx
@@ -104,15 +104,15 @@ export function RegisterForm() {
   }
 
   return (
-    <div className="w-full max-w-2xl rounded-2xl overflow-hidden shadow-xl border border-slate-200 bg-white">
-      <div className="bg-black text-white text-center py-4">
+    <div className="w-full max-w-2xl overflow-hidden rounded-3xl border border-border/70 bg-card shadow-xl shadow-primary/10 transition-colors">
+      <div className="bg-gradient-to-r from-primary to-accent py-4 text-center text-primary-foreground">
         <h1 className="text-lg font-semibold tracking-wide">Referral Signup System</h1>
       </div>
 
-      <div className="px-6 sm:px-8 py-6 space-y-6">
+      <div className="space-y-6 px-6 py-6 sm:px-8">
         <div className="flex justify-center">
-          <div className="w-14 h-14 rounded-full border border-slate-300 flex items-center justify-center text-slate-600">
-            <UserPlus className="w-8 h-8" />
+          <div className="flex h-14 w-14 items-center justify-center rounded-full border border-border/60 bg-background/80 text-primary shadow-sm">
+            <UserPlus className="h-8 w-8" />
           </div>
         </div>
 
@@ -125,7 +125,7 @@ export function RegisterForm() {
         <form onSubmit={handleSubmit} className="space-y-5">
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
-              <Label htmlFor="name" className="text-sm font-semibold text-slate-700">
+              <Label htmlFor="name" className="text-sm font-semibold text-foreground/90">
                 Name
               </Label>
               <Input
@@ -134,12 +134,12 @@ export function RegisterForm() {
                 value={formData.name}
                 onChange={(event) => setFormData((prev) => ({ ...prev, name: event.target.value }))}
                 required
-                className="h-11 rounded-md border-slate-300 bg-slate-50 text-slate-700 placeholder:text-slate-400"
+                className="h-11"
               />
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="email" className="text-sm font-semibold text-slate-700">
+              <Label htmlFor="email" className="text-sm font-semibold text-foreground/90">
                 Email
               </Label>
               <Input
@@ -149,13 +149,13 @@ export function RegisterForm() {
                 value={formData.email}
                 onChange={(event) => setFormData((prev) => ({ ...prev, email: event.target.value }))}
                 required
-                className="h-11 rounded-md border-slate-300 bg-slate-50 text-slate-700 placeholder:text-slate-400"
+                className="h-11"
               />
             </div>
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="phone" className="text-sm font-semibold text-slate-700">
+            <Label htmlFor="phone" className="text-sm font-semibold text-foreground/90">
               Phone Number
             </Label>
             <div className="flex flex-col sm:flex-row sm:items-center gap-2">
@@ -163,7 +163,7 @@ export function RegisterForm() {
                 value={formData.countryCode}
                 onValueChange={(value) => setFormData((prev) => ({ ...prev, countryCode: value }))}
               >
-                <SelectTrigger className="sm:w-40 h-11 rounded-md border-slate-300 bg-slate-50 text-slate-700">
+                <SelectTrigger className="h-11 rounded-md sm:w-40">
                   <SelectValue placeholder="Country" />
                 </SelectTrigger>
                 <SelectContent className="max-h-64">
@@ -184,7 +184,7 @@ export function RegisterForm() {
                   setFormData((prev) => ({ ...prev, phone: event.target.value.replace(/[^\d]/g, "") }))
                 }
                 required
-                className="h-11 flex-1 rounded-md border-slate-300 bg-slate-50 text-slate-700 placeholder:text-slate-400"
+                className="h-11 flex-1"
               />
             </div>
             <p className="text-xs text-muted-foreground">
@@ -194,7 +194,7 @@ export function RegisterForm() {
 
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
-              <Label htmlFor="password" className="text-sm font-semibold text-slate-700">
+              <Label htmlFor="password" className="text-sm font-semibold text-foreground/90">
                 Password
               </Label>
               <Input
@@ -205,12 +205,12 @@ export function RegisterForm() {
                 onChange={(event) => setFormData((prev) => ({ ...prev, password: event.target.value }))}
                 required
                 minLength={6}
-                className="h-11 rounded-md border-slate-300 bg-slate-50 text-slate-700 placeholder:text-slate-400"
+                className="h-11"
               />
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="confirmPassword" className="text-sm font-semibold text-slate-700">
+              <Label htmlFor="confirmPassword" className="text-sm font-semibold text-foreground/90">
                 Re-enter Password
               </Label>
               <Input
@@ -223,13 +223,13 @@ export function RegisterForm() {
                 }
                 required
                 minLength={6}
-                className="h-11 rounded-md border-slate-300 bg-slate-50 text-slate-700 placeholder:text-slate-400"
+                className="h-11"
               />
             </div>
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="referralCode" className="text-sm font-semibold text-slate-700">
+            <Label htmlFor="referralCode" className="text-sm font-semibold text-foreground/90">
               Referral Code
             </Label>
             <Input
@@ -244,17 +244,12 @@ export function RegisterForm() {
             />
           </div>
 
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-            <Button
-              type="button"
-              variant="outline"
-              className="sm:w-auto h-11 border-black text-black hover:bg-black/10"
-              onClick={() => router.push("/auth/forgot")}
-            >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <Button type="button" variant="outline" className="h-11 sm:w-auto" onClick={() => router.push("/auth/forgot")}>
               Forgot Password?
             </Button>
 
-            <Button type="submit" className="h-11 flex-1 sm:flex-none bg-black hover:bg-black/90" disabled={isLoading}>
+            <Button type="submit" className="h-11 flex-1 sm:flex-none shadow-lg shadow-primary/20" disabled={isLoading}>
               {isLoading ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -267,9 +262,9 @@ export function RegisterForm() {
           </div>
         </form>
 
-        <p className="text-center text-sm text-slate-600">
+        <p className="text-center text-sm text-muted-foreground">
           Already have an account?{" "}
-          <Link href="/auth/login" className="font-semibold text-black hover:underline">
+          <Link href="/auth/login" className="font-semibold text-primary hover:underline">
             Login instead
           </Link>
         </p>

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { NotificationBell } from "@/components/notifications/notification-bell"
+import { ThemeToggle } from "@/components/theme-toggle"
 import Image from "next/image"
 import {
   Home,
@@ -70,8 +71,9 @@ export function Sidebar({ user }: SidebarProps) {
           <Image src="/images/logo.png" alt="Mintmine Pro" width={32} height={32} className="rounded-lg" />
           <span className="text-lg font-bold text-sidebar-foreground">Mintmine Pro</span>
         </div>
-        <div className="md:hidden">
+        <div className="md:hidden flex items-center gap-2">
           <NotificationBell />
+          <ThemeToggle />
         </div>
       </div>
 
@@ -153,8 +155,9 @@ export function Sidebar({ user }: SidebarProps) {
         <SidebarContent />
       </div>
 
-      <div className="hidden md:block fixed top-4 right-6 z-50">
+      <div className="fixed top-4 right-6 z-50 hidden items-center gap-3 md:flex">
         <NotificationBell />
+        <ThemeToggle />
       </div>
     </>
   )

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { MoonStar, Sun } from "lucide-react"
+import { useTheme } from "next-themes"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return (
+      <Button variant="ghost" size="icon" className="relative" aria-label="Toggle theme" disabled>
+        <Sun className="h-5 w-5 opacity-0" />
+      </Button>
+    )
+  }
+
+  const isDark = resolvedTheme === "dark"
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      className="relative overflow-hidden"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+    >
+      <Sun className={cn("h-5 w-5 transition-all", isDark ? "-rotate-90 scale-0" : "rotate-0 scale-100")} />
+      <MoonStar
+        className={cn(
+          "absolute h-5 w-5 transition-all",
+          isDark ? "rotate-0 scale-100" : "rotate-90 scale-0",
+        )}
+      />
+    </Button>
+  )
+}

--- a/components/wallet/deposit-form.tsx
+++ b/components/wallet/deposit-form.tsx
@@ -165,8 +165,8 @@ export function DepositForm({ options, minDeposit, onSuccess }: DepositFormProps
       )}
 
       {state?.success && (
-        <Alert className="border-green-200 bg-green-50">
-          <div className="flex items-center gap-2 text-green-700">
+        <Alert className="border border-emerald-400/60 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200">
+          <div className="flex items-center gap-2">
             <CheckCircle className="h-4 w-4" />
             <AlertDescription>{state.success}</AlertDescription>
           </div>
@@ -174,9 +174,9 @@ export function DepositForm({ options, minDeposit, onSuccess }: DepositFormProps
       )}
 
       {/* Network Selection */}
-      <section className="rounded-3xl border border-slate-200 bg-gradient-to-br from-white via-slate-50 to-slate-100 p-5 shadow-sm dark:from-slate-900 dark:via-slate-900/60 dark:to-slate-900">
+      <section className="rounded-3xl border border-border/80 bg-card/90 p-5 shadow-lg shadow-primary/10 transition-colors">
         <div className="space-y-4">
-          <Label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
+          <Label className="text-sm font-semibold text-foreground/90">
             Select Network
           </Label>
           <div className="grid gap-3 sm:grid-cols-3">
@@ -187,15 +187,15 @@ export function DepositForm({ options, minDeposit, onSuccess }: DepositFormProps
                   key={option.id}
                   type="button"
                   onClick={() => setSelectedOptionId(option.id)}
-                  className={`rounded-xl border p-4 text-left transition-shadow ${
+                  className={`rounded-xl border p-4 text-left transition-all ${
                     isSelected
-                      ? "border-emerald-500 bg-emerald-50 shadow-md dark:bg-emerald-950"
-                      : "border-slate-200 hover:shadow"
+                      ? "border-primary bg-primary/10 shadow-lg shadow-primary/30"
+                      : "border-border/70 bg-background/70 hover:border-primary/60 hover:shadow"
                   }`}
                 >
                   <p className="text-xs uppercase text-muted-foreground">{option.network}</p>
-                  <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">{option.label}</p>
-                  <p className="mt-2 break-all font-mono text-xs text-slate-600 dark:text-slate-300">
+                  <p className="text-sm font-semibold text-foreground">{option.label}</p>
+                  <p className="mt-2 break-all font-mono text-xs text-muted-foreground">
                     {option.address}
                   </p>
                 </button>
@@ -206,14 +206,18 @@ export function DepositForm({ options, minDeposit, onSuccess }: DepositFormProps
 
         <div className="mt-6 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
           <div className="space-y-3 md:max-w-md">
-            <p className="text-sm font-semibold text-slate-600 dark:text-slate-300">Deposit address</p>
+            <p className="text-sm font-semibold text-muted-foreground">Deposit address</p>
             <div className="flex flex-col gap-3 sm:flex-row">
-              <Input readOnly value={selectedAddress} className="h-12 rounded-xl bg-white font-mono text-sm shadow-inner dark:bg-slate-950" />
+              <Input
+                readOnly
+                value={selectedAddress}
+                className="h-12 rounded-xl bg-background/80 font-mono text-sm shadow-inner dark:bg-input/40"
+              />
               <Button
                 type="button"
                 variant="secondary"
                 onClick={handleCopy}
-                className="h-12 rounded-xl border-slate-300 text-sm font-semibold shadow-sm"
+                className="h-12 rounded-xl border border-border/60 text-sm font-semibold shadow-sm"
               >
                 {copied ? (
                   <>
@@ -229,18 +233,22 @@ export function DepositForm({ options, minDeposit, onSuccess }: DepositFormProps
           </div>
           {selectedAddress && (
             <div className="flex shrink-0 justify-center">
-              <img src={qrCodeUrl} alt="Deposit address QR code" className="h-44 w-44 rounded-xl border bg-white p-2 shadow-md" />
+              <img
+                src={qrCodeUrl}
+                alt="Deposit address QR code"
+                className="h-44 w-44 rounded-xl border border-border/60 bg-card p-2 shadow-md"
+              />
             </div>
           )}
         </div>
       </section>
 
       {/* Deposit Form */}
-      <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950">
+      <section className="rounded-3xl border border-border/80 bg-card p-5 shadow-lg shadow-primary/5">
         <div className="grid gap-5 md:grid-cols-2">
           <div className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="deposit-amount" className="text-sm font-semibold">
+              <Label htmlFor="deposit-amount" className="text-sm font-semibold text-foreground/90">
                 Amount (USDT)
               </Label>
               <Input
@@ -260,7 +268,7 @@ export function DepositForm({ options, minDeposit, onSuccess }: DepositFormProps
             </div>
 
             <div className="space-y-2">
-              <Label className="text-sm font-semibold">Exchange</Label>
+              <Label className="text-sm font-semibold text-foreground/90">Exchange</Label>
               <Select
                 value={formState.exchangePlatform}
                 onValueChange={(value) =>
@@ -282,7 +290,7 @@ export function DepositForm({ options, minDeposit, onSuccess }: DepositFormProps
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="transaction-number" className="text-sm font-semibold">
+              <Label htmlFor="transaction-number" className="text-sm font-semibold text-foreground/90">
                 Transaction Hash
               </Label>
               <Input
@@ -302,7 +310,7 @@ export function DepositForm({ options, minDeposit, onSuccess }: DepositFormProps
 
           {/* Upload Section */}
           <div className="space-y-3">
-            <Label htmlFor="transaction-receipt" className="text-sm font-semibold">
+            <Label htmlFor="transaction-receipt" className="text-sm font-semibold text-foreground/90">
               Upload Confirmation Screenshot
             </Label>
             <Input
@@ -316,7 +324,7 @@ export function DepositForm({ options, minDeposit, onSuccess }: DepositFormProps
             />
 
             {receiptFile && (
-              <div className="flex items-center gap-3 rounded-xl border border-dashed border-slate-300 p-3">
+              <div className="flex items-center gap-3 rounded-xl border border-dashed border-border/70 bg-background/80 p-3">
                 {receiptPreview ? (
                   <img src={receiptPreview} alt="Transaction receipt preview" className="h-16 w-16 rounded-lg object-cover shadow-sm" />
                 ) : (


### PR DESCRIPTION
## Summary
- add a reusable theme toggle powered by next-themes and surface it beside the notification bell
- wrap the app with the theme provider and refresh landing/auth pages with palette-aware gradients and cards
- modernize wallet deposit styles to respect the design tokens in both light and dark modes

## Testing
- npm run lint *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68df50015ffc8327bd8a1e766d8f1be9