### PR TITLE
Proxy admin receipt previews through secure endpoint

### DIFF
--- a/app/api/admin/transactions/receipt-preview/route.ts
+++ b/app/api/admin/transactions/receipt-preview/route.ts
@@ -1,0 +1,74 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { getUserFromRequest } from "@/lib/auth"
+import dbConnect from "@/lib/mongodb"
+import User from "@/models/User"
+
+export async function GET(request: NextRequest) {
+  try {
+    const userPayload = getUserFromRequest(request)
+    if (!userPayload) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    await dbConnect()
+
+    const adminUser = await User.findById(userPayload.userId).select("role")
+    if (!adminUser || adminUser.role !== "admin") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const urlParam = searchParams.get("url")
+
+    if (!urlParam) {
+      return NextResponse.json({ error: "Missing receipt URL" }, { status: 400 })
+    }
+
+    let targetUrl: URL
+    try {
+      targetUrl = /^https?:/i.test(urlParam)
+        ? new URL(urlParam)
+        : new URL(urlParam, request.nextUrl.origin)
+    } catch (error) {
+      return NextResponse.json({ error: "Invalid receipt URL" }, { status: 400 })
+    }
+
+    if (!["http:", "https:"].includes(targetUrl.protocol)) {
+      return NextResponse.json({ error: "Unsupported receipt protocol" }, { status: 400 })
+    }
+
+    const forwardedHeaders = new Headers()
+    if (targetUrl.origin === request.nextUrl.origin) {
+      const cookie = request.headers.get("cookie")
+      if (cookie) {
+        forwardedHeaders.set("cookie", cookie)
+      }
+    }
+
+    const response = await fetch(targetUrl.toString(), {
+      cache: "no-store",
+      headers: forwardedHeaders,
+    })
+
+    if (!response.ok) {
+      return NextResponse.json({ error: "Unable to load receipt" }, { status: response.status })
+    }
+
+    const arrayBuffer = await response.arrayBuffer()
+    const headers = new Headers()
+    const contentType = response.headers.get("content-type") || "application/octet-stream"
+    const contentLength = response.headers.get("content-length") || String(arrayBuffer.byteLength)
+
+    headers.set("Content-Type", contentType)
+    headers.set("Content-Length", contentLength)
+    headers.set("Cache-Control", "no-store")
+
+    return new NextResponse(arrayBuffer, {
+      status: 200,
+      headers,
+    })
+  } catch (error) {
+    console.error("Receipt preview error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/app/api/admin/transactions/route.ts
+++ b/app/api/admin/transactions/route.ts
@@ -19,15 +19,15 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url)
-    const type = searchParams.get("type")
-    const status = searchParams.get("status")
-    const page = Number.parseInt(searchParams.get("page") || "1")
-    const limit = Number.parseInt(searchParams.get("limit") || "20")
+    const typeParam = searchParams.get("type")
+    const statusParam = searchParams.get("status")
+    const page = Math.max(1, Number.parseInt(searchParams.get("page") || "1"))
+    const limit = Math.min(100, Math.max(1, Number.parseInt(searchParams.get("limit") || "20")))
 
     // Build query
     const query: any = {}
-    if (type) query.type = type
-    if (status) query.status = status
+    if (typeParam && typeParam !== "all") query.type = typeParam
+    if (statusParam && statusParam !== "all") query.status = statusParam
 
     // Get transactions with user data
     const transactions = await Transaction.find(query)

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -19,9 +19,10 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url)
-    const search = searchParams.get("search")
-    const page = Number.parseInt(searchParams.get("page") || "1")
-    const limit = Number.parseInt(searchParams.get("limit") || "20")
+    const searchRaw = searchParams.get("search")
+    const search = searchRaw ? searchRaw.trim() : ""
+    const page = Math.max(1, Number.parseInt(searchParams.get("page") || "1"))
+    const limit = Math.min(100, Math.max(1, Number.parseInt(searchParams.get("limit") || "20")))
 
     // Build query
     const query: any = {}

--- a/components/admin/transaction-table.tsx
+++ b/components/admin/transaction-table.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -47,17 +47,29 @@ type ReceiptMeta = {
   checksum?: string
 }
 
+interface PaginationMeta {
+  page: number
+  pages: number
+  limit: number
+  total: number
+}
+
 interface TransactionTableProps {
   transactions: Transaction[]
+  pagination: PaginationMeta
+  onPageChange: (page: number) => void
   onRefresh: () => void
 }
 
-export function TransactionTable({ transactions, onRefresh }: TransactionTableProps) {
+export function TransactionTable({ transactions, pagination, onPageChange, onRefresh }: TransactionTableProps) {
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null)
   const [showRejectDialog, setShowRejectDialog] = useState(false)
   const [rejectReason, setRejectReason] = useState("")
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState("")
+  const [imageError, setImageError] = useState(false)
+  const [receiptPreviewUrl, setReceiptPreviewUrl] = useState<string | null>(null)
+  const [previewLoading, setPreviewLoading] = useState(false)
 
   const receiptMeta =
     selectedTransaction?.type === "deposit" && selectedTransaction.meta?.receipt
@@ -70,6 +82,87 @@ export function TransactionTable({ transactions, onRefresh }: TransactionTablePr
       : null
 
   const selectedAmount = selectedTransaction ? Number(selectedTransaction.amount) : Number.NaN
+
+  const resolvedReceiptUrl = useMemo(() => {
+    if (!receiptMeta?.url || typeof receiptMeta.url !== "string") {
+      return null
+    }
+
+    if (/^https?:\/\//i.test(receiptMeta.url)) {
+      return receiptMeta.url
+    }
+
+    return receiptMeta.url.startsWith("/") ? receiptMeta.url : `/${receiptMeta.url}`
+  }, [receiptMeta?.url])
+
+  useEffect(() => {
+    let isCancelled = false
+    let objectUrl: string | null = null
+
+    if (!resolvedReceiptUrl) {
+      setReceiptPreviewUrl(null)
+      setImageError(false)
+      setPreviewLoading(false)
+      return () => {
+        if (objectUrl) URL.revokeObjectURL(objectUrl)
+      }
+    }
+
+    const fetchPreview = async () => {
+      setReceiptPreviewUrl(null)
+      setPreviewLoading(true)
+      setImageError(false)
+
+      try {
+        const params = new URLSearchParams({ url: resolvedReceiptUrl })
+        const response = await fetch(`/api/admin/transactions/receipt-preview?${params.toString()}`)
+
+        if (!response.ok) {
+          throw new Error("Failed to load preview")
+        }
+
+        const blob = await response.blob()
+        if (isCancelled) return
+
+        objectUrl = URL.createObjectURL(blob)
+        setReceiptPreviewUrl(objectUrl)
+      } catch (error) {
+        if (!isCancelled) {
+          setReceiptPreviewUrl(null)
+          setImageError(true)
+        }
+      } finally {
+        if (!isCancelled) {
+          setPreviewLoading(false)
+        }
+      }
+    }
+
+    fetchPreview()
+
+    return () => {
+      isCancelled = true
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl)
+      }
+    }
+  }, [resolvedReceiptUrl])
+
+  const paginationStart = (pagination.page - 1) * pagination.limit + 1
+  const paginationEnd = Math.min(pagination.page * pagination.limit, pagination.total)
+  const hasNextPage = pagination.page < pagination.pages || transactions.length === pagination.limit
+
+  const handlePreviousPage = () => {
+    if (pagination.page > 1) {
+      onPageChange(pagination.page - 1)
+    }
+  }
+
+  const handleNextPage = () => {
+    if (hasNextPage) {
+      onPageChange(pagination.page + 1)
+    }
+  }
 
   const handleApprove = async (transaction: Transaction) => {
     setLoading(true)
@@ -183,80 +276,107 @@ export function TransactionTable({ transactions, onRefresh }: TransactionTablePr
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {transactions.map((transaction) => {
-                  const userRecord =
-                    transaction.userId && typeof transaction.userId === "object"
-                      ? transaction.userId
-                      : null
+                {transactions.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center text-sm text-muted-foreground">
+                      No transactions found for the selected filters.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  transactions.map((transaction) => {
+                    const userRecord =
+                      transaction.userId && typeof transaction.userId === "object"
+                        ? transaction.userId
+                        : null
 
-                  const amountValue = Number(transaction.amount)
-                  const createdAt = transaction.createdAt ? new Date(transaction.createdAt) : null
-                  const fallbackIdentifier =
-                    userRecord?._id || (typeof transaction.userId === "string" ? transaction.userId : undefined)
-                  const isPending = transaction.status === "pending"
+                    const amountValue = Number(transaction.amount)
+                    const createdAt = transaction.createdAt ? new Date(transaction.createdAt) : null
+                    const fallbackIdentifier =
+                      userRecord?._id || (typeof transaction.userId === "string" ? transaction.userId : undefined)
+                    const isPending = transaction.status === "pending"
 
-                  return (
-                    <TableRow key={transaction._id}>
-                      <TableCell>
-                        <div>
-                          <div className="font-medium">
-                            {userRecord?.name || "Deleted user"}
+                    return (
+                      <TableRow key={transaction._id}>
+                        <TableCell>
+                          <div>
+                            <div className="font-medium">
+                              {userRecord?.name || "Deleted user"}
+                            </div>
+                            <div className="text-sm text-muted-foreground">
+                              {userRecord?.email || "User record unavailable"}
+                            </div>
+                            <div className="text-xs font-mono">
+                              {userRecord?.referralCode || fallbackIdentifier || "—"}
+                            </div>
                           </div>
-                          <div className="text-sm text-muted-foreground">
-                            {userRecord?.email || "User record unavailable"}
+                        </TableCell>
+                        <TableCell>{getTypeBadge(transaction.type)}</TableCell>
+                        <TableCell className="font-mono">
+                          {Number.isFinite(amountValue) ? `$${amountValue.toFixed(2)}` : "—"}
+                        </TableCell>
+                        <TableCell>{getStatusBadge(transaction.status)}</TableCell>
+                        <TableCell>
+                          {createdAt && !Number.isNaN(createdAt.getTime())
+                            ? createdAt.toLocaleDateString()
+                            : "—"}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center space-x-2">
+                            <Button variant="ghost" size="sm" onClick={() => setSelectedTransaction(transaction)}>
+                              <Eye className="h-4 w-4" />
+                            </Button>
+                            {isPending && (
+                              <>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => handleApprove(transaction)}
+                                  disabled={loading}
+                                  className="text-green-600 hover:text-green-700"
+                                >
+                                  {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+                                </Button>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => {
+                                    setSelectedTransaction(transaction)
+                                    setShowRejectDialog(true)
+                                  }}
+                                  disabled={loading}
+                                  className="text-red-600 hover:text-red-700"
+                                >
+                                  <X className="h-4 w-4" />
+                                </Button>
+                              </>
+                            )}
                           </div>
-                          <div className="text-xs font-mono">
-                            {userRecord?.referralCode || fallbackIdentifier || "—"}
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>{getTypeBadge(transaction.type)}</TableCell>
-                      <TableCell className="font-mono">
-                        {Number.isFinite(amountValue) ? `$${amountValue.toFixed(2)}` : "—"}
-                      </TableCell>
-                      <TableCell>{getStatusBadge(transaction.status)}</TableCell>
-                      <TableCell>
-                        {createdAt && !Number.isNaN(createdAt.getTime())
-                          ? createdAt.toLocaleDateString()
-                          : "—"}
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex items-center space-x-2">
-                          <Button variant="ghost" size="sm" onClick={() => setSelectedTransaction(transaction)}>
-                            <Eye className="h-4 w-4" />
-                          </Button>
-                          {isPending && (
-                            <>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleApprove(transaction)}
-                                disabled={loading}
-                                className="text-green-600 hover:text-green-700"
-                              >
-                                {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => {
-                                  setSelectedTransaction(transaction)
-                                  setShowRejectDialog(true)
-                                }}
-                                disabled={loading}
-                                className="text-red-600 hover:text-red-700"
-                              >
-                                <X className="h-4 w-4" />
-                              </Button>
-                            </>
-                          )}
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  )
-                })}
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })
+                )}
               </TableBody>
             </Table>
+          </div>
+
+          <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-muted-foreground">
+              {pagination.total > 0
+                ? `Showing ${paginationStart.toLocaleString()}-${paginationEnd.toLocaleString()} of ${pagination.total.toLocaleString()} transactions`
+                : "No transactions to display"}
+            </p>
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" onClick={handlePreviousPage} disabled={pagination.page <= 1}>
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {Math.min(pagination.page, pagination.pages).toLocaleString()} of {Math.max(pagination.pages, 1).toLocaleString()}
+              </span>
+              <Button variant="outline" size="sm" onClick={handleNextPage} disabled={!hasNextPage}>
+                Next
+              </Button>
+            </div>
           </div>
         </CardContent>
       </Card>
@@ -295,28 +415,45 @@ export function TransactionTable({ transactions, onRefresh }: TransactionTablePr
               {receiptMeta?.url && (
                 <div className="space-y-2">
                   <Label>Receipt Screenshot</Label>
-                  <div className="overflow-hidden rounded-md border bg-muted/60">
-                    <img
-                      src={receiptMeta.url}
-                      alt={`Deposit receipt ${receiptMeta.originalName ?? ""}`}
-                      className="max-h-96 w-full object-contain bg-background"
-                    />
-                  </div>
-                  <div className="text-xs text-muted-foreground space-y-1">
+                  {previewLoading ? (
+                    <div className="flex min-h-[12rem] items-center justify-center rounded-md border bg-muted/60">
+                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                        Loading receipt preview…
+                      </div>
+                    </div>
+                  ) : receiptPreviewUrl && !imageError ? (
+                    <div className="overflow-hidden rounded-md border bg-muted/60">
+                      <img
+                        src={receiptPreviewUrl}
+                        alt={`Deposit receipt ${receiptMeta.originalName ?? ""}`}
+                        className="max-h-96 w-full bg-background object-contain"
+                      />
+                    </div>
+                  ) : (
+                    <div className="rounded-md border bg-muted/60 p-4 text-sm text-muted-foreground">
+                      Receipt preview unavailable. Use the link below to view the original file.
+                    </div>
+                  )}
+                  <div className="space-y-1 text-xs text-muted-foreground">
                     {receiptMeta.originalName && <div>File: {receiptMeta.originalName}</div>}
-                    {typeof receiptMeta.size === "number" && <div>Size: {(receiptMeta.size / 1024 / 1024).toFixed(2)} MB</div>}
+                    {typeof receiptMeta.size === "number" && (
+                      <div>Size: {(receiptMeta.size / 1024 / 1024).toFixed(2)} MB</div>
+                    )}
                     {receiptMeta.uploadedAt && (
                       <div>Uploaded: {new Date(receiptMeta.uploadedAt).toLocaleString()}</div>
                     )}
                   </div>
-                  <a
-                    href={receiptMeta.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-sm font-medium text-primary hover:underline"
-                  >
-                    Open full receipt
-                  </a>
+                  {resolvedReceiptUrl && (
+                    <a
+                      href={resolvedReceiptUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-sm font-medium text-primary hover:underline"
+                    >
+                      Open full receipt
+                    </a>
+                  )}
                 </div>
               )}
 

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -71,7 +71,7 @@ export function Sidebar({ user }: SidebarProps) {
           <Image src="/images/logo.png" alt="Mintmine Pro" width={32} height={32} className="rounded-lg" />
           <span className="text-lg font-bold text-sidebar-foreground">Mintmine Pro</span>
         </div>
-        <div className="md:hidden flex items-center gap-2">
+        <div className="md:hidden mt-2 flex items-center gap-2">
           <NotificationBell />
           <ThemeToggle />
         </div>
@@ -141,11 +141,15 @@ export function Sidebar({ user }: SidebarProps) {
       {/* Mobile sidebar */}
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetTrigger asChild>
-         <Button  variant="ghost" size="icon" className="md:hidden ">
-  <Menu className="h-12 w-12" /> {/* aur bada */}
-</Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="md:hidden h-16 w-16 rounded-2xl border border-border shadow-sm"
+          >
+            <Menu className="h-12 w-12" />
+          </Button>
         </SheetTrigger>
-        <SheetContent side="left" className="w-64 p-0">
+        <SheetContent side="left" hideClose className="w-64 p-0">
           <SidebarContent />
         </SheetContent>
       </Sheet>
@@ -155,7 +159,7 @@ export function Sidebar({ user }: SidebarProps) {
         <SidebarContent />
       </div>
 
-      <div className="fixed top-4 right-6 z-50 hidden items-center gap-3 md:flex">
+      <div className="fixed top-8 right-6 z-50 hidden items-center gap-3 md:flex">
         <NotificationBell />
         <ThemeToggle />
       </div>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -48,9 +48,11 @@ function SheetContent({
   className,
   children,
   side = 'right',
+  hideClose = false,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: 'top' | 'right' | 'bottom' | 'left'
+  hideClose?: boolean
 }) {
   return (
     <SheetPortal>
@@ -72,10 +74,12 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-          <XIcon className="size-4" />
-          <span className="sr-only">Close</span>
-        </SheetPrimitive.Close>
+        {!hideClose && (
+          <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
       </SheetPrimitive.Content>
     </SheetPortal>
   )

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -187,7 +187,8 @@ function Sidebar({
           data-sidebar="sidebar"
           data-slot="sidebar"
           data-mobile="true"
-          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0"
+          hideClose
           style={
             {
               '--sidebar-width': SIDEBAR_WIDTH_MOBILE,


### PR DESCRIPTION
## Summary
- add an authenticated admin API route that proxies receipt URLs so previews can be fetched with the right cookies
- load transaction receipt screenshots through the new preview endpoint with a loading state and object URL handling
- keep the existing fallback message for failures while showing a spinner during preview fetches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df614470c48327b9b4ba10c90e522f