### PR TITLE
Improve admin UX after resolving merge conflicts

### DIFF
--- a/components/admin/admin-dashboard.tsx
+++ b/components/admin/admin-dashboard.tsx
@@ -102,8 +102,9 @@ export function AdminDashboard({
       const userParams = new URLSearchParams()
       userParams.set("page", nextUserPage.toString())
       userParams.set("limit", PAGE_SIZE.toString())
-      if (userSearch.trim().length > 0) {
-        userParams.set("search", userSearch.trim())
+      const sanitizedSearch = userSearch.trim()
+      if (sanitizedSearch.length > 0) {
+        userParams.set("search", sanitizedSearch)
       }
 
       const [userRes, transactionsRes, usersRes] = await Promise.all([

--- a/components/admin/transaction-table.tsx
+++ b/components/admin/transaction-table.tsx
@@ -141,6 +141,12 @@ export function TransactionTable({ transactions, pagination, onPageChange, onRef
   const handleReject = async () => {
     if (!selectedTransaction) return
 
+    const trimmedReason = rejectReason.trim()
+    if (!trimmedReason) {
+      setError("Please provide a reason for rejecting the transaction.")
+      return
+    }
+
     setLoading(true)
     setError("")
 
@@ -150,7 +156,7 @@ export function TransactionTable({ transactions, pagination, onPageChange, onRef
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           transactionId: selectedTransaction._id,
-          reason: rejectReason,
+          reason: trimmedReason,
         }),
       })
 
@@ -435,7 +441,7 @@ export function TransactionTable({ transactions, pagination, onPageChange, onRef
             <Button variant="outline" onClick={() => setShowRejectDialog(false)}>
               Cancel
             </Button>
-            <Button variant="destructive" onClick={handleReject} disabled={loading || !rejectReason}>
+            <Button variant="destructive" onClick={handleReject} disabled={loading || !rejectReason.trim()}>
               {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
               Reject Transaction
             </Button>

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
@@ -54,6 +54,10 @@ export function Sidebar({ user }: SidebarProps) {
   const router = useRouter()
   const [open, setOpen] = useState(false)
 
+  useEffect(() => {
+    setOpen(false)
+  }, [pathname])
+
   const handleLogout = async () => {
     try {
       await fetch("/api/auth/logout", { method: "POST" })
@@ -80,7 +84,8 @@ export function Sidebar({ user }: SidebarProps) {
       {/* Navigation */}
       <nav className="flex-1 space-y-1 px-3 py-4">
         {navigation.map((item) => {
-          const isActive = pathname === item.href
+          const isActive =
+            pathname === item.href || pathname.startsWith(`${item.href}/`)
           return (
             <Link
               key={item.name}
@@ -102,7 +107,7 @@ export function Sidebar({ user }: SidebarProps) {
           <Link
             href="/admin"
             className={`flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
-              pathname === "/admin"
+              pathname === "/admin" || pathname.startsWith("/admin/")
                 ? "bg-sidebar-accent text-sidebar-accent-foreground"
                 : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
             }`}
@@ -125,7 +130,10 @@ export function Sidebar({ user }: SidebarProps) {
           <Button
             variant="ghost"
             size="sm"
-            onClick={handleLogout}
+            onClick={() => {
+              setOpen(false)
+              void handleLogout()
+            }}
             className="w-full justify-start text-sidebar-foreground "
           >
             <LogOut className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- sanitize the admin user search query before issuing refresh requests
- require a trimmed rejection reason before rejecting a transaction and show a validation error when missing
- auto-close the sidebar on navigation/logout and support nested route highlighting for active links

## Testing
- pnpm lint *(fails: prompts for ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df6b8991d88327b5919a944d57d14e