### PR TITLE
Add inline email OTP verification for signup and password resets

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -9,3 +9,15 @@ NEXTAUTH_URL=http://localhost:3000
 DEPOSIT_WALLET_ADDRESS_1=0x9e2d640110ee86ea961a3864f842db21baada57d
 DEPOSIT_WALLET_ADRESS_2=0x1fd48cff68A51030B4A8334d0e2718Be19b78bfA
 DEPOSIT_WALLET_ADRESS_3=TRhSCE8igyVmMuuRqukZEQDkn3MuEAdvfw
+
+# =======================
+# SMTP (Gmail with App Password)
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=mintminepro@gmail.com
+SMTP_PASS=cukc asvy xvtm mnif
+
+# (Optional) If you decide to use OAuth2 instead of App Password
+GOOGLE_CLIENT_ID=54048701215-ogl5kcrrsqsdvqnrbtcdmerbgfu56c3m.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=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
+GOOGLE_REFRESH_TOKEN=your-refresh-token-here

--- a/app/api/auth/send-otp/route.ts
+++ b/app/api/auth/send-otp/route.ts
@@ -52,16 +52,14 @@ export async function POST(request: NextRequest) {
       })
       console.log("[v0] Created OTP record:", otpRecord._id)
 
-      const isDevelopment = process.env.NODE_ENV === "development"
-      const hasEmailConfig = process.env.SMTP_USER && process.env.SMTP_PASS
+      const hasEmailConfig = Boolean(process.env.SMTP_USER && process.env.SMTP_PASS)
 
-      if (isDevelopment && !hasEmailConfig) {
-        console.log("[v0] Development mode: Skipping email send, OTP:", otpCode)
-        return NextResponse.json({
-          success: true,
-          message: "OTP sent to your email address",
-          developmentOTP: otpCode,
-        })
+      if (!hasEmailConfig) {
+        console.error("[v0] Email configuration missing. Cannot send OTP email.")
+        return NextResponse.json(
+          { error: "Email service is not configured. Please contact support." },
+          { status: 500 },
+        )
       }
 
       try {
@@ -70,18 +68,15 @@ export async function POST(request: NextRequest) {
         console.log("[v0] Email sent successfully")
       } catch (emailError) {
         console.error("[v0] Email sending failed:", emailError)
-        return NextResponse.json({
-          success: true,
-          message: "OTP sent to your email address",
-          ...(isDevelopment && { developmentOTP: otpCode }),
-          warning: isDevelopment ? "Email sending failed, using development mode" : undefined,
-        })
+        return NextResponse.json(
+          { error: "Failed to send verification email. Please try again later." },
+          { status: 500 },
+        )
       }
 
       return NextResponse.json({
         success: true,
         message: "OTP sent to your email address",
-        ...(isDevelopment && { developmentOTP: otpCode }),
       })
     }
 
@@ -112,16 +107,14 @@ export async function POST(request: NextRequest) {
       })
       console.log("[v0] Created phone OTP record:", otpRecord._id)
 
-      const isDevelopment = process.env.NODE_ENV === "development"
-      const hasSMSConfig = process.env.TWILIO_ACCOUNT_SID && process.env.TWILIO_AUTH_TOKEN
+      const hasSMSConfig = Boolean(process.env.TWILIO_ACCOUNT_SID && process.env.TWILIO_AUTH_TOKEN)
 
-      if (isDevelopment && !hasSMSConfig) {
-        console.log("[v0] Development mode: Skipping SMS send, OTP:", otpCode)
-        return NextResponse.json({
-          success: true,
-          message: "OTP sent to your phone number",
-          developmentOTP: otpCode,
-        })
+      if (!hasSMSConfig) {
+        console.error("[v0] SMS configuration missing. Cannot send OTP SMS.")
+        return NextResponse.json(
+          { error: "SMS service is not configured. Please use email verification." },
+          { status: 500 },
+        )
       }
 
       try {
@@ -130,18 +123,15 @@ export async function POST(request: NextRequest) {
         console.log("[v0] SMS sent successfully")
       } catch (smsError) {
         console.error("[v0] SMS sending failed:", smsError)
-        return NextResponse.json({
-          success: true,
-          message: "OTP sent to your phone number",
-          ...(isDevelopment && { developmentOTP: otpCode }),
-          warning: isDevelopment ? "SMS sending failed, using development mode" : undefined,
-        })
+        return NextResponse.json(
+          { error: "Failed to send verification code via SMS. Please try again later." },
+          { status: 500 },
+        )
       }
 
       return NextResponse.json({
         success: true,
         message: "OTP sent to your phone number",
-        ...(isDevelopment && { developmentOTP: otpCode }),
       })
     }
 

--- a/app/auth/forgot/page.tsx
+++ b/app/auth/forgot/page.tsx
@@ -27,7 +27,6 @@ export default function ForgotPasswordPage() {
   const [verifiedCode, setVerifiedCode] = useState<string | null>(null)
   const [otpCountdown, setOtpCountdown] = useState(0)
   const [isResending, setIsResending] = useState(false)
-  const [developmentOTP, setDevelopmentOTP] = useState<string | null>(null)
 
   useEffect(() => {
     return () => {
@@ -53,7 +52,6 @@ export default function ForgotPasswordPage() {
     setVerifiedCode(null)
     setOtpCountdown(0)
     setIsResending(false)
-    setDevelopmentOTP(null)
   }
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -82,9 +80,6 @@ export default function ForgotPasswordPage() {
         }
 
         setSuccess("Verification code sent to your email. Enter it below to verify your account.")
-        if (typeof (data as { developmentOTP?: string }).developmentOTP === "string") {
-          setDevelopmentOTP((data as { developmentOTP: string }).developmentOTP)
-        }
         setStep("verify")
         setOtpValue("")
         setOtpCountdown(60)
@@ -206,9 +201,6 @@ export default function ForgotPasswordPage() {
       }
 
       setSuccess("A new verification code has been sent to your email.")
-      if (typeof (data as { developmentOTP?: string }).developmentOTP === "string") {
-        setDevelopmentOTP((data as { developmentOTP: string }).developmentOTP)
-      }
       setOtpValue("")
       setOtpCountdown(60)
       setVerifiedCode(null)
@@ -299,9 +291,6 @@ export default function ForgotPasswordPage() {
                     )}
                   </Button>
                 </div>
-                {developmentOTP && (
-                  <p className="text-center text-xs font-medium text-primary">Development OTP: {developmentOTP}</p>
-                )}
               </div>
             )}
 

--- a/components/auth/contact-method-selector.tsx
+++ b/components/auth/contact-method-selector.tsx
@@ -7,8 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Mail, Phone, Info } from "lucide-react"
+import { Mail, Phone } from "lucide-react"
 
 interface ContactMethodSelectorProps {
   onSubmit: (data: { email?: string; phone?: string; method: "email" | "phone" }) => void
@@ -20,45 +19,19 @@ export function ContactMethodSelector({ onSubmit, isLoading, error }: ContactMet
   const [activeTab, setActiveTab] = useState<"email" | "phone">("email")
   const [email, setEmail] = useState("")
   const [phone, setPhone] = useState("")
-  const [developmentOTP, setDevelopmentOTP] = useState<string | null>(null)
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    setDevelopmentOTP(null) // Clear previous OTP
-
     console.log("[v0] Form submitted with:", { activeTab, email, phone })
 
     const submitData = activeTab === "email" ? { email, method: "email" as const } : { phone, method: "phone" as const }
 
-    try {
-      await onSubmit(submitData)
-    } catch (err: any) {
-      console.error("[v0] Submit error:", err)
-      // Check if response contains development OTP
-      if (err.developmentOTP) {
-        setDevelopmentOTP(err.developmentOTP)
-      }
-    }
+    await onSubmit(submitData)
   }
 
   return (
     <div className="space-y-4">
-      {process.env.NODE_ENV === "development" && (
-        <Alert className="border-blue-200 bg-blue-50">
-          <Info className="h-4 w-4" />
-          <AlertDescription className="text-blue-800">
-            Development Mode: OTP will be displayed here instead of being sent via email/SMS.
-          </AlertDescription>
-        </Alert>
-      )}
-
-      {developmentOTP && (
-        <Alert className="border-green-200 bg-green-50">
-          <AlertDescription className="text-green-800">
-            <strong>Development OTP:</strong> {developmentOTP}
-          </AlertDescription>
-        </Alert>
-      )}
+      {error && <p className="text-sm text-destructive">{error}</p>}
 
       <form onSubmit={handleSubmit} className="space-y-4">
         <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as "email" | "phone")}>

--- a/components/auth/register-form.tsx
+++ b/components/auth/register-form.tsx
@@ -51,7 +51,6 @@ export function RegisterForm() {
   const [otpValue, setOtpValue] = useState("")
   const [otpCountdown, setOtpCountdown] = useState(0)
   const [isResending, setIsResending] = useState(false)
-  const [developmentOTP, setDevelopmentOTP] = useState<string | null>(null)
 
   // Prefill referral code from query param (?ref= or ?referral=), once on mount / when URL changes
   useEffect(() => {
@@ -83,7 +82,6 @@ export function RegisterForm() {
     setOtpValue("")
     setOtpCountdown(0)
     setIsResending(false)
-    setDevelopmentOTP(null)
     setInfoMessage("")
   }
 
@@ -124,10 +122,7 @@ export function RegisterForm() {
           return
         }
 
-        setInfoMessage("Verification code sent to your email. Enter it below to finish signing up.")
-        if (typeof (data as { developmentOTP?: string }).developmentOTP === "string") {
-          setDevelopmentOTP((data as { developmentOTP: string }).developmentOTP)
-        }
+        setInfoMessage("Verification code sent to your email. Enter it below to verify your account.")
         setStep("otp")
         setOtpValue("")
         setOtpCountdown(60)
@@ -220,9 +215,6 @@ export function RegisterForm() {
       }
 
       setInfoMessage("A new verification code has been sent to your email.")
-      if (typeof (data as { developmentOTP?: string }).developmentOTP === "string") {
-        setDevelopmentOTP((data as { developmentOTP: string }).developmentOTP)
-      }
       setOtpValue("")
       setOtpCountdown(60)
     } catch (resendError) {
@@ -442,9 +434,6 @@ export function RegisterForm() {
                   )}
                 </Button>
               </div>
-              {developmentOTP && (
-                <p className="text-center text-xs font-medium text-primary">Development OTP: {developmentOTP}</p>
-              )}
             </div>
           )}
 

--- a/components/auth/register-form.tsx
+++ b/components/auth/register-form.tsx
@@ -1,9 +1,9 @@
 "use client"
 
-import { type FormEvent, useEffect, useState } from "react"
+import { type FormEvent, useEffect, useMemo, useState } from "react"
 import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
-import { Loader2, UserPlus } from "lucide-react"
+import { Loader2, RefreshCw, UserPlus } from "lucide-react"
 
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
@@ -17,6 +17,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { SORTED_COUNTRY_DIAL_CODES } from "@/lib/constants/country-codes"
+import { OTPInput } from "@/components/auth/otp-input"
 
 const PHONE_REGEX = /^\+[1-9]\d{7,14}$/
 
@@ -45,6 +46,12 @@ export function RegisterForm() {
   })
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState("")
+  const [infoMessage, setInfoMessage] = useState("")
+  const [step, setStep] = useState<"details" | "otp">("details")
+  const [otpValue, setOtpValue] = useState("")
+  const [otpCountdown, setOtpCountdown] = useState(0)
+  const [isResending, setIsResending] = useState(false)
+  const [developmentOTP, setDevelopmentOTP] = useState<string | null>(null)
 
   // Prefill referral code from query param (?ref= or ?referral=), once on mount / when URL changes
   useEffect(() => {
@@ -55,51 +62,174 @@ export function RegisterForm() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]) // don't include formData in deps to avoid unnecessary resets
 
+  useEffect(() => {
+    if (otpCountdown <= 0) return
+
+    const timer = setInterval(() => {
+      setOtpCountdown((prev) => (prev > 0 ? prev - 1 : 0))
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [otpCountdown])
+
+  const normalizedEmail = useMemo(() => formData.email.trim().toLowerCase(), [formData.email])
+  const normalizedPhone = useMemo(() => {
+    const cleanedPhone = formData.phone.replace(/\D/g, "")
+    return `${formData.countryCode}${cleanedPhone}`
+  }, [formData.countryCode, formData.phone])
+
+  const resetOTPState = () => {
+    setStep("details")
+    setOtpValue("")
+    setOtpCountdown(0)
+    setIsResending(false)
+    setDevelopmentOTP(null)
+    setInfoMessage("")
+  }
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     setError("")
+    if (step !== "otp") {
+      setInfoMessage("")
+    }
 
-    if (formData.password !== formData.confirmPassword) {
-      setError("Passwords do not match")
+    if (step === "details") {
+      if (formData.password !== formData.confirmPassword) {
+        setError("Passwords do not match")
+        return
+      }
+
+      if (!PHONE_REGEX.test(normalizedPhone)) {
+        setError("Please enter a valid international phone number")
+        return
+      }
+
+      setIsLoading(true)
+
+      try {
+        const response = await fetch("/api/auth/send-otp", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: normalizedEmail,
+            purpose: "registration",
+          }),
+        })
+
+        const data = await response.json().catch(() => ({}))
+
+        if (!response.ok) {
+          setError((data as { error?: string }).error || "Failed to send verification code")
+          return
+        }
+
+        setInfoMessage("Verification code sent to your email. Enter it below to finish signing up.")
+        if (typeof (data as { developmentOTP?: string }).developmentOTP === "string") {
+          setDevelopmentOTP((data as { developmentOTP: string }).developmentOTP)
+        }
+        setStep("otp")
+        setOtpValue("")
+        setOtpCountdown(60)
+      } catch (submitError) {
+        console.error("Send OTP error", submitError)
+        setError("Network error. Please try again.")
+      } finally {
+        setIsLoading(false)
+      }
+
       return
     }
 
-    const cleanedPhone = formData.phone.replace(/\D/g, "")
-    const normalizedPhone = `${formData.countryCode}${cleanedPhone}`
-
-    if (!PHONE_REGEX.test(normalizedPhone)) {
-      setError("Please enter a valid international phone number")
+    if (otpValue.length !== 6) {
+      setError("Please enter the 6-digit verification code")
       return
     }
 
     setIsLoading(true)
 
     try {
-      const response = await fetch("/api/auth/register", {
+      const verifyResponse = await fetch("/api/auth/verify-otp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          code: otpValue,
+          email: normalizedEmail,
+          purpose: "registration",
+        }),
+      })
+
+      const verifyData = await verifyResponse.json().catch(() => ({}))
+
+      if (!verifyResponse.ok) {
+        setError((verifyData as { error?: string }).error || "Verification failed")
+        return
+      }
+
+      const registerResponse = await fetch("/api/auth/register-with-otp", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: formData.name.trim(),
-          email: formData.email.trim().toLowerCase(),
+          email: normalizedEmail,
           phone: normalizedPhone,
           password: formData.password,
           referralCode: formData.referralCode.trim().toUpperCase(),
+          otpCode: otpValue,
+        }),
+      })
+
+      const registerData = await registerResponse.json().catch(() => ({}))
+
+      if (!registerResponse.ok) {
+        setError((registerData as { error?: string }).error || "Registration failed")
+        return
+      }
+
+      router.push("/dashboard")
+    } catch (submitError) {
+      console.error("Registration with OTP error", submitError)
+      setError("Network error. Please try again.")
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleResendOTP = async () => {
+    if (isResending || step !== "otp") return
+
+    setError("")
+    setInfoMessage("")
+    setIsResending(true)
+
+    try {
+      const response = await fetch("/api/auth/send-otp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: normalizedEmail,
+          purpose: "registration",
         }),
       })
 
       const data = await response.json().catch(() => ({}))
 
       if (!response.ok) {
-        setError((data as { error?: string }).error || "Registration failed")
+        setError((data as { error?: string }).error || "Failed to resend code")
         return
       }
 
-      router.push("/dashboard")
-    } catch (submitError) {
-      console.error("Registration error", submitError)
+      setInfoMessage("A new verification code has been sent to your email.")
+      if (typeof (data as { developmentOTP?: string }).developmentOTP === "string") {
+        setDevelopmentOTP((data as { developmentOTP: string }).developmentOTP)
+      }
+      setOtpValue("")
+      setOtpCountdown(60)
+    } catch (resendError) {
+      console.error("Resend OTP error", resendError)
       setError("Network error. Please try again.")
     } finally {
-      setIsLoading(false)
+      setIsResending(false)
     }
   }
 
@@ -122,6 +252,12 @@ export function RegisterForm() {
           </Alert>
         )}
 
+        {infoMessage && (
+          <Alert>
+            <AlertDescription>{infoMessage}</AlertDescription>
+          </Alert>
+        )}
+
         <form onSubmit={handleSubmit} className="space-y-5">
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
@@ -132,7 +268,12 @@ export function RegisterForm() {
                 id="name"
                 placeholder="Enter name"
                 value={formData.name}
-                onChange={(event) => setFormData((prev) => ({ ...prev, name: event.target.value }))}
+                onChange={(event) => {
+                  setFormData((prev) => ({ ...prev, name: event.target.value }))
+                  if (step === "otp") {
+                    resetOTPState()
+                  }
+                }}
                 required
                 className="h-11"
               />
@@ -147,9 +288,15 @@ export function RegisterForm() {
                 type="email"
                 placeholder="Enter email"
                 value={formData.email}
-                onChange={(event) => setFormData((prev) => ({ ...prev, email: event.target.value }))}
+                onChange={(event) => {
+                  setFormData((prev) => ({ ...prev, email: event.target.value }))
+                  if (step === "otp") {
+                    resetOTPState()
+                  }
+                }}
                 required
                 className="h-11"
+                disabled={step === "otp"}
               />
             </div>
           </div>
@@ -158,10 +305,16 @@ export function RegisterForm() {
             <Label htmlFor="phone" className="text-sm font-semibold text-foreground/90">
               Phone Number
             </Label>
-            <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
               <Select
                 value={formData.countryCode}
-                onValueChange={(value) => setFormData((prev) => ({ ...prev, countryCode: value }))}
+                onValueChange={(value) => {
+                  setFormData((prev) => ({ ...prev, countryCode: value }))
+                  if (step === "otp") {
+                    resetOTPState()
+                  }
+                }}
+                disabled={step === "otp"}
               >
                 <SelectTrigger className="h-11 rounded-md sm:w-40">
                   <SelectValue placeholder="Country" />
@@ -180,11 +333,15 @@ export function RegisterForm() {
                 inputMode="tel"
                 placeholder="123456789"
                 value={formData.phone}
-                onChange={(event) =>
+                onChange={(event) => {
                   setFormData((prev) => ({ ...prev, phone: event.target.value.replace(/[^\d]/g, "") }))
-                }
+                  if (step === "otp") {
+                    resetOTPState()
+                  }
+                }}
                 required
                 className="h-11 flex-1"
+                disabled={step === "otp"}
               />
             </div>
             <p className="text-xs text-muted-foreground">
@@ -202,10 +359,16 @@ export function RegisterForm() {
                 type="password"
                 placeholder="Enter password"
                 value={formData.password}
-                onChange={(event) => setFormData((prev) => ({ ...prev, password: event.target.value }))}
+                onChange={(event) => {
+                  setFormData((prev) => ({ ...prev, password: event.target.value }))
+                  if (step === "otp") {
+                    resetOTPState()
+                  }
+                }}
                 required
                 minLength={6}
                 className="h-11"
+                disabled={step === "otp"}
               />
             </div>
 
@@ -218,12 +381,16 @@ export function RegisterForm() {
                 type="password"
                 placeholder="Re-enter password"
                 value={formData.confirmPassword}
-                onChange={(event) =>
+                onChange={(event) => {
                   setFormData((prev) => ({ ...prev, confirmPassword: event.target.value }))
-                }
+                  if (step === "otp") {
+                    resetOTPState()
+                  }
+                }}
                 required
                 minLength={6}
                 className="h-11"
+                disabled={step === "otp"}
               />
             </div>
           </div>
@@ -237,26 +404,67 @@ export function RegisterForm() {
               type="text"
               placeholder="Enter referral code (required)"
               value={formData.referralCode}
-              onChange={(e) =>
-                setFormData((prev) => ({ ...prev, referralCode: e.target.value.toUpperCase() }))
-              }
+              onChange={(event) => {
+                setFormData((prev) => ({ ...prev, referralCode: event.target.value.toUpperCase() }))
+                if (step === "otp") {
+                  resetOTPState()
+                }
+              }}
               required
+              disabled={step === "otp"}
             />
           </div>
 
+          {step === "otp" && (
+            <div className="space-y-3">
+              <div className="space-y-2 text-center">
+                <Label className="text-sm font-semibold text-foreground/90">Enter the 6-digit code</Label>
+                <OTPInput value={otpValue} onChange={setOtpValue} disabled={isLoading} />
+              </div>
+              <div className="flex flex-col items-center justify-center gap-2 text-xs text-muted-foreground sm:flex-row">
+                <span>
+                  {otpCountdown > 0 ? `You can request a new code in ${otpCountdown}s` : "Didn't get the code?"}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleResendOTP}
+                  disabled={isResending || otpCountdown > 0}
+                  className="h-8 px-2"
+                >
+                  {isResending ? (
+                    <>
+                      <RefreshCw className="mr-1 h-3 w-3 animate-spin" /> Resending...
+                    </>
+                  ) : (
+                    "Resend code"
+                  )}
+                </Button>
+              </div>
+              {developmentOTP && (
+                <p className="text-center text-xs font-medium text-primary">Development OTP: {developmentOTP}</p>
+              )}
+            </div>
+          )}
+
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <Button type="button" variant="outline" className="h-11 sm:w-auto" onClick={() => router.push("/auth/forgot")}>
-              Forgot Password?
-            </Button>
+            {step === "details" && (
+              <Button type="button" variant="outline" className="h-11 sm:w-auto" onClick={() => router.push("/auth/forgot")}>
+                Forgot Password?
+              </Button>
+            )}
 
             <Button type="submit" className="h-11 flex-1 sm:flex-none shadow-lg shadow-primary/20" disabled={isLoading}>
               {isLoading ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Registering...
+                  {step === "details" ? "Sending Code..." : "Verifying..."}
                 </>
+              ) : step === "details" ? (
+                "Send Verification Code"
               ) : (
-                "Register"
+                "Verify & Create Account"
               )}
             </Button>
           </div>

--- a/lib/utils/email.tsx
+++ b/lib/utils/email.tsx
@@ -1,7 +1,7 @@
 import nodemailer from "nodemailer"
 
 const createTransporter = () => {
-  return nodemailer.createTransporter({
+  return nodemailer.createTransport({
     host: process.env.SMTP_HOST || "smtp.gmail.com",
     port: Number.parseInt(process.env.SMTP_PORT || "587"),
     secure: false, // true for 465, false for other ports

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -42,6 +42,7 @@ export const loginSchema = z
 export const resetPasswordSchema = z.object({
   email: z.string().email("Invalid email address"),
   password: z.string().min(6, "Password must be at least 6 characters"),
+  otpCode: z.string().length(6, "OTP must be 6 digits"),
 })
 
 export type RegisterInput = z.infer<typeof registerSchema>


### PR DESCRIPTION
## Summary
- gate user registration behind an email-based OTP flow on the existing signup page, including resend and countdown handling
- add inline OTP verification to the forgot-password screen and require the verified code before allowing a password update
- validate OTP codes in the reset-password API and clear them once used

## Testing
- npm run lint *(fails: command prompts for configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0127d6e608327bd972549e90cfca9