### PR TITLE
Remove Google font dependency from layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,9 @@
 import type React from "react"
 import type { Metadata } from "next"
-import { Inter } from "next/font/google"
-
 import { ThemeProvider } from "@/components/theme-provider"
 import { cn } from "@/lib/utils"
 
 import "./globals.css"
-
-const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
   title: "CryptoMine - Next-Generation Mining Platform",
@@ -23,7 +19,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={cn("min-h-screen bg-background font-sans antialiased text-foreground", inter.className)}>
+      <body className={cn("min-h-screen bg-background font-sans antialiased text-foreground")}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
           {children}
         </ThemeProvider>


### PR DESCRIPTION
## Summary
- stop importing the Google-hosted Inter font in the root layout to avoid build-time network fetches
- rely on the existing Tailwind sans-serif stack while retaining the global typography classes

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0305fcd1c832798be216aa8d29b0c