### PR TITLE
Rebrand frontend to Apple Mine with orchard-themed UI

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,4 +1,4 @@
-# CryptoMine Platform Setup Guide
+# Apple Mine Platform Setup Guide
 
 ## Quick Setup Instructions
 

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -2,8 +2,12 @@ import { LoginForm } from "@/components/auth/login-form"
 
 export default function LoginPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-[hsl(var(--background))] via-[hsl(var(--secondary))] to-[hsl(var(--muted))] p-4 text-foreground transition-colors dark:from-[#050505] dark:via-[#0a0a0a] dark:to-[#141414] sm:p-6">
-      <LoginForm />
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#010b08] p-4 text-foreground sm:p-6">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(74,222,128,0.18),_transparent_55%)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(248,250,252,0.07),_transparent_50%)]" />
+      <div className="relative z-10 w-full max-w-xl">
+        <LoginForm />
+      </div>
     </div>
   )
 }

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -3,10 +3,14 @@ import { RegisterForm } from "@/components/auth/register-form"
 
 export default function RegisterPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-[hsl(var(--background))] via-[hsl(var(--secondary))] to-[hsl(var(--muted))] p-4 text-foreground transition-colors dark:from-[#050505] dark:via-[#0a0a0a] dark:to-[#141414] sm:p-6">
-      <Suspense fallback={<div className="text-sm text-muted-foreground">Preparing form...</div>}>
-        <RegisterForm />
-      </Suspense>
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#010b08] p-4 text-foreground sm:p-6">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(74,222,128,0.18),_transparent_55%)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(248,250,252,0.07),_transparent_50%)]" />
+      <div className="relative z-10 w-full max-w-3xl">
+        <Suspense fallback={<div className="text-sm text-emerald-100/70">Preparing form...</div>}>
+          <RegisterForm />
+        </Suspense>
+      </div>
     </div>
   )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,76 +4,76 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  /* Enhanced crypto-focused color scheme with better contrast and modern aesthetics */
-  --background: oklch(0.98 0.005 240);
-  --foreground: oklch(0.15 0.02 240);
+  /* Orchard-inspired palette for Apple Mine */
+  --background: oklch(0.98 0.015 135);
+  --foreground: oklch(0.18 0.022 145);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.15 0.02 240);
+  --card-foreground: oklch(0.19 0.022 145);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.15 0.02 240);
-  --primary: oklch(0.55 0.18 45); /* Crypto gold/amber */
-  --primary-foreground: oklch(0.98 0.005 240);
-  --secondary: oklch(0.96 0.01 240);
-  --secondary-foreground: oklch(0.25 0.02 240);
-  --muted: oklch(0.96 0.01 240);
-  --muted-foreground: oklch(0.55 0.02 240);
-  --accent: oklch(0.55 0.18 45);
-  --accent-foreground: oklch(0.98 0.005 240);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.98 0.005 240);
-  --border: oklch(0.92 0.01 240);
-  --input: oklch(0.92 0.01 240);
-  --ring: oklch(0.55 0.18 45);
-  --chart-1: oklch(0.55 0.18 45); /* Crypto gold */
-  --chart-2: oklch(0.45 0.15 200); /* Crypto blue */
-  --chart-3: oklch(0.35 0.12 280); /* Crypto purple */
-  --chart-4: oklch(0.65 0.15 120); /* Crypto green */
-  --chart-5: oklch(0.5 0.2 15); /* Crypto orange */
+  --popover-foreground: oklch(0.18 0.022 145);
+  --primary: oklch(0.76 0.12 136); /* fresh apple green */
+  --primary-foreground: oklch(0.14 0.02 150);
+  --secondary: oklch(0.95 0.02 170);
+  --secondary-foreground: oklch(0.28 0.02 160);
+  --muted: oklch(0.96 0.015 160);
+  --muted-foreground: oklch(0.55 0.018 160);
+  --accent: oklch(0.84 0.16 95); /* citrus glow */
+  --accent-foreground: oklch(0.18 0.022 145);
+  --destructive: oklch(0.54 0.19 25);
+  --destructive-foreground: oklch(0.99 0.004 160);
+  --border: oklch(0.9 0.012 155);
+  --input: oklch(0.9 0.012 155);
+  --ring: oklch(0.76 0.12 136);
+  --chart-1: oklch(0.76 0.12 136);
+  --chart-2: oklch(0.68 0.13 180);
+  --chart-3: oklch(0.7 0.16 95);
+  --chart-4: oklch(0.64 0.14 125);
+  --chart-5: oklch(0.72 0.17 55);
   --radius: 0.75rem;
-  --sidebar: oklch(0.98 0.005 240);
-  --sidebar-foreground: oklch(0.15 0.02 240);
-  --sidebar-primary: oklch(0.55 0.18 45);
-  --sidebar-primary-foreground: oklch(0.98 0.005 240);
-  --sidebar-accent: oklch(0.96 0.01 240);
-  --sidebar-accent-foreground: oklch(0.25 0.02 240);
-  --sidebar-border: oklch(0.92 0.01 240);
-  --sidebar-ring: oklch(0.55 0.18 45);
+  --sidebar: oklch(0.98 0.015 135);
+  --sidebar-foreground: oklch(0.19 0.022 145);
+  --sidebar-primary: oklch(0.76 0.12 136);
+  --sidebar-primary-foreground: oklch(0.14 0.02 150);
+  --sidebar-accent: oklch(0.95 0.02 170);
+  --sidebar-accent-foreground: oklch(0.28 0.02 160);
+  --sidebar-border: oklch(0.9 0.012 155);
+  --sidebar-ring: oklch(0.76 0.12 136);
 }
 
 .dark {
-  /* Enhanced dark theme with better crypto aesthetics and improved contrast */
-  --background: oklch(0.08 0.01 240);
-  --foreground: oklch(0.95 0.005 240);
-  --card: oklch(0.12 0.01 240);
-  --card-foreground: oklch(0.95 0.005 240);
-  --popover: oklch(0.12 0.01 240);
-  --popover-foreground: oklch(0.95 0.005 240);
-  --primary: oklch(0.65 0.2 45); /* Brighter crypto gold for dark mode */
-  --primary-foreground: oklch(0.08 0.01 240);
-  --secondary: oklch(0.18 0.01 240);
-  --secondary-foreground: oklch(0.95 0.005 240);
-  --muted: oklch(0.18 0.01 240);
-  --muted-foreground: oklch(0.65 0.01 240);
-  --accent: oklch(0.65 0.2 45);
-  --accent-foreground: oklch(0.08 0.01 240);
-  --destructive: oklch(0.55 0.2 25);
-  --destructive-foreground: oklch(0.95 0.005 240);
-  --border: oklch(0.18 0.01 240);
-  --input: oklch(0.18 0.01 240);
-  --ring: oklch(0.65 0.2 45);
-  --chart-1: oklch(0.65 0.2 45); /* Bright crypto gold */
-  --chart-2: oklch(0.55 0.18 200); /* Bright crypto blue */
-  --chart-3: oklch(0.45 0.15 280); /* Bright crypto purple */
-  --chart-4: oklch(0.75 0.18 120); /* Bright crypto green */
-  --chart-5: oklch(0.6 0.22 15); /* Bright crypto orange */
-  --sidebar: oklch(0.1 0.01 240);
-  --sidebar-foreground: oklch(0.95 0.005 240);
-  --sidebar-primary: oklch(0.65 0.2 45);
-  --sidebar-primary-foreground: oklch(0.08 0.01 240);
-  --sidebar-accent: oklch(0.18 0.01 240);
-  --sidebar-accent-foreground: oklch(0.95 0.005 240);
-  --sidebar-border: oklch(0.18 0.01 240);
-  --sidebar-ring: oklch(0.65 0.2 45);
+  /* Deep orchard night palette */
+  --background: oklch(0.11 0.018 150);
+  --foreground: oklch(0.94 0.008 150);
+  --card: oklch(0.15 0.02 150);
+  --card-foreground: oklch(0.94 0.008 150);
+  --popover: oklch(0.15 0.02 150);
+  --popover-foreground: oklch(0.94 0.008 150);
+  --primary: oklch(0.7 0.13 136);
+  --primary-foreground: oklch(0.13 0.022 155);
+  --secondary: oklch(0.24 0.02 160);
+  --secondary-foreground: oklch(0.94 0.008 150);
+  --muted: oklch(0.24 0.02 160);
+  --muted-foreground: oklch(0.67 0.01 160);
+  --accent: oklch(0.77 0.15 95);
+  --accent-foreground: oklch(0.13 0.022 155);
+  --destructive: oklch(0.54 0.19 25);
+  --destructive-foreground: oklch(0.98 0.006 150);
+  --border: oklch(0.24 0.02 160);
+  --input: oklch(0.24 0.02 160);
+  --ring: oklch(0.7 0.13 136);
+  --chart-1: oklch(0.7 0.13 136);
+  --chart-2: oklch(0.62 0.12 190);
+  --chart-3: oklch(0.64 0.14 95);
+  --chart-4: oklch(0.58 0.13 125);
+  --chart-5: oklch(0.66 0.16 55);
+  --sidebar: oklch(0.14 0.018 150);
+  --sidebar-foreground: oklch(0.94 0.008 150);
+  --sidebar-primary: oklch(0.7 0.13 136);
+  --sidebar-primary-foreground: oklch(0.13 0.022 155);
+  --sidebar-accent: oklch(0.24 0.02 160);
+  --sidebar-accent-foreground: oklch(0.94 0.008 150);
+  --sidebar-border: oklch(0.24 0.02 160);
+  --sidebar-ring: oklch(0.7 0.13 136);
 }
 
 @theme inline {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,10 +6,10 @@ import { cn } from "@/lib/utils"
 import "./globals.css"
 
 export const metadata: Metadata = {
-  title: "CryptoMine - Next-Generation Mining Platform",
+  title: "Apple Mine – Immersive Digital Mining Collective",
   description:
-    "Join our innovative mining ecosystem with referral rewards, team building, and sustainable earning opportunities.",
-    generator: 'v0.app'
+    "Experience Apple Mine's orchard-inspired mining hub with collaborative rewards, layered security, and beautifully designed dashboards.",
+  generator: "v0.app",
 }
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,89 +1,263 @@
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
-import { ArrowRight, Shield, Users, Zap } from "lucide-react"
-import Image from "next/image"
+import {
+  ArrowRight,
+  CircleDashed,
+  Gem,
+  Leaf,
+  Pickaxe,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react"
+
+const featureHighlights = [
+  {
+    title: "Orchard Mining Pods",
+    description:
+      "Spin up immersive mining pods that blend gamified orchard visuals with precise earnings data and smart automation.",
+    icon: Pickaxe,
+  },
+  {
+    title: "Collective Harvest",
+    description:
+      "Empower your crew with layered referral rewards, collaborative streaks, and storytelling dashboards that celebrate wins.",
+    icon: Leaf,
+  },
+  {
+    title: "Vault-Grade Guardrails",
+    description:
+      "Defend every transaction with multifactor checkpoints, anomaly detection, and real-time ledger transparency.",
+    icon: ShieldCheck,
+  },
+]
+
+const journeySteps = [
+  {
+    title: "Plant Your Node",
+    detail: "Create your Apple Mine identity in under a minute with secure email or global phone authentication.",
+  },
+  {
+    title: "Nurture Your Network",
+    detail: "Invite cultivators, unlock layered yields, and monitor orchard health with intuitive growth analytics.",
+  },
+  {
+    title: "Harvest Daily",
+    detail: "Trigger luminous mining sessions, collect auto-compounded rewards, and withdraw with zero friction.",
+  },
+]
+
+const impactStats = [
+  { value: "98.4%", label: "Average Daily Uptime" },
+  { value: "72k+", label: "Rewards Distributed" },
+  { value: "140", label: "Countries Mining Together" },
+]
 
 export default function HomePage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-[hsl(var(--background))] via-[hsl(var(--secondary))] to-[hsl(var(--muted))] text-foreground transition-colors dark:from-[#050505] dark:via-[#0c0c0c] dark:to-[#161616]">
-      {/* Header */}
-      <header className="border-b border-border/60 bg-card/80 backdrop-blur-md supports-[backdrop-filter]:bg-card/60 dark:bg-[#101010]/80">
-        <div className="container mx-auto flex items-center justify-between px-4 py-4">
-          <div className="flex items-center space-x-2">
-            <Image src="/images/logo.png" alt="Mintmine Pro" width={32} height={32} className="rounded-lg" />
-            <span className="text-xl font-bold">Mintmine Pro</span>
-          </div>
-          <div className="flex items-center space-x-3">
+    <div className="relative min-h-screen overflow-hidden bg-[#030910] text-foreground">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(74,222,128,0.12),_transparent_55%)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(250,204,21,0.08),_transparent_45%)]" />
+
+      <header className="relative z-10 border-b border-white/5 bg-white/5 backdrop-blur-xl">
+        <div className="container mx-auto flex flex-col gap-4 px-4 py-6 md:flex-row md:items-center md:justify-between">
+          <Link href="/" className="group flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-lime-400 via-emerald-500 to-amber-400 text-2xl font-black text-emerald-950 shadow-[0_0_25px_rgba(34,197,94,0.35)] transition-transform group-hover:rotate-6">
+              🍏
+            </div>
+            <div>
+              <p className="text-lg font-semibold uppercase tracking-[0.3em] text-emerald-200/80">Apple Mine</p>
+              <p className="-mt-1 text-sm font-medium text-emerald-100/70">Cultivate Digital Wealth</p>
+            </div>
+          </Link>
+
+          <nav className="flex flex-wrap items-center gap-4 text-sm font-medium text-emerald-100/80 md:gap-8">
+            <Link href="/dashboard" className="transition hover:text-emerald-200">
+              Platform
+            </Link>
+            <Link href="/mining" className="transition hover:text-emerald-200">
+              Mining Arena
+            </Link>
+            <Link href="/wallet" className="transition hover:text-emerald-200">
+              Wallet
+            </Link>
+            <Link href="/support" className="transition hover:text-emerald-200">
+              Support
+            </Link>
+          </nav>
+
+          <div className="flex items-center gap-3">
             <Link href="/auth/login">
-              <Button variant="ghost">Sign In</Button>
+              <Button variant="outline" className="border-emerald-400/40 bg-emerald-400/5 text-emerald-100 hover:bg-emerald-400/20">
+                Sign In
+              </Button>
             </Link>
             <Link href="/auth/register">
-              <Button className="shadow-lg shadow-primary/20">Get Started</Button>
+              <Button className="bg-gradient-to-r from-emerald-400 via-lime-400 to-amber-300 text-emerald-950 shadow-lg shadow-emerald-400/25 hover:from-emerald-300 hover:via-lime-300 hover:to-amber-200">
+                Join the Orchard
+              </Button>
             </Link>
           </div>
         </div>
       </header>
 
-      {/* Hero Section */}
-      <main className="container mx-auto px-4 py-16">
-        <div className="mx-auto max-w-4xl text-center">
-          <h1 className="text-balance text-5xl font-bold leading-tight sm:text-6xl">
-            Next-Generation
-            <span className="bg-gradient-to-r from-primary via-accent to-primary/80 bg-clip-text text-transparent">
-              {" "}
-              Crypto Mining{" "}
-            </span>
-            Platform
-          </h1>
-          <p className="mt-6 text-balance text-lg text-muted-foreground sm:text-xl">
-            Join our innovative mining ecosystem with referral rewards, team building, and sustainable earning
-            opportunities.
-          </p>
-          <div className="mt-8 flex flex-col justify-center gap-4 sm:flex-row">
-            <Link href="/auth/register">
-              <Button size="lg" className="px-8 text-lg shadow-lg shadow-primary/25">
-                Start Mining Today
-                <ArrowRight className="ml-2 h-5 w-5" />
-              </Button>
-            </Link>
-            <Link href="/auth/login">
-              <Button size="lg" variant="outline" className="px-8 text-lg">
-                Sign In
-              </Button>
-            </Link>
-          </div>
-        </div>
+      <main className="relative z-10">
+        <section className="container mx-auto px-4 pb-24 pt-16 md:pt-24">
+          <div className="grid gap-12 lg:grid-cols-[1.15fr_0.85fr] lg:items-center">
+            <div className="space-y-8">
+              <span className="inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200">
+                <Sparkles className="h-3.5 w-3.5" />
+                Orchard-Powered Mining
+              </span>
+              <h1 className="text-balance text-4xl font-black leading-tight text-white sm:text-5xl md:text-6xl">
+                Harvest luminous rewards with the reimagined <span className="bg-gradient-to-r from-emerald-200 via-lime-200 to-amber-200 bg-clip-text text-transparent">Apple Mine</span> universe.
+              </h1>
+              <p className="max-w-2xl text-lg text-emerald-100/70 sm:text-xl">
+                Apple Mine distills pro-grade crypto infrastructure into a cinematic experience. Navigate glowing grids,
+                coordinate mining parties, and withdraw earnings inside a serene, orchard-inspired interface.
+              </p>
+              <div className="flex flex-col gap-4 sm:flex-row">
+                <Link href="/auth/register">
+                  <Button size="lg" className="h-14 rounded-full bg-gradient-to-r from-emerald-400 via-lime-400 to-amber-300 px-10 text-base font-semibold text-emerald-950 shadow-xl shadow-emerald-400/30">
+                    Launch My Pod
+                    <ArrowRight className="ml-2 h-5 w-5" />
+                  </Button>
+                </Link>
+                <Link href="/auth/login">
+                  <Button size="lg" variant="outline" className="h-14 rounded-full border-emerald-400/40 bg-transparent px-10 text-base text-emerald-100 transition hover:bg-emerald-400/10">
+                    I already cultivate here
+                  </Button>
+                </Link>
+              </div>
+              <div className="grid gap-6 sm:grid-cols-3">
+                {impactStats.map((stat) => (
+                  <div key={stat.label} className="rounded-2xl border border-white/10 bg-white/5 p-5 shadow-[0_0_25px_rgba(15,118,110,0.15)]">
+                    <p className="text-3xl font-bold text-white">{stat.value}</p>
+                    <p className="text-sm font-medium uppercase tracking-wider text-emerald-100/70">{stat.label}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
 
-        {/* Features */}
-        <div className="mt-20 grid gap-8 md:grid-cols-3">
-          <div className="group rounded-3xl border border-border/60 bg-card/80 p-6 shadow-lg shadow-primary/10 transition-all hover:-translate-y-1 hover:border-primary/60 hover:shadow-primary/30">
-            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-accent text-primary-foreground shadow-lg shadow-primary/30">
-              <Zap className="h-8 w-8" />
+            <div className="relative">
+              <div className="absolute inset-0 rounded-[3rem] bg-gradient-to-br from-emerald-500/20 via-lime-400/10 to-amber-300/20 blur-3xl" />
+              <div className="relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-black/40 p-8 shadow-[0_25px_60px_rgba(15,118,110,0.45)]">
+                <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.35em] text-emerald-100/60">
+                  <span>Live Yield Matrix</span>
+                  <CircleDashed className="h-4 w-4" />
+                </div>
+                <div className="mt-8 space-y-6">
+                  <div className="rounded-3xl border border-emerald-400/30 bg-emerald-400/10 p-6">
+                    <div className="flex items-center justify-between text-sm text-emerald-100/80">
+                      <span>Flux Reactor</span>
+                      <span>+12.4%</span>
+                    </div>
+                    <h3 className="mt-3 flex items-center gap-2 text-2xl font-semibold text-white">
+                      <Gem className="h-6 w-6 text-amber-300" />
+                      Aurora Cluster
+                    </h3>
+                    <p className="mt-3 text-sm text-emerald-100/60">
+                      Autonomous pod compounding every 24h with orchard synergy boosts and AI-powered balancing.
+                    </p>
+                  </div>
+
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="rounded-3xl border border-white/10 bg-white/5 p-5 text-sm text-emerald-100/80">
+                      <p className="text-xs uppercase tracking-[0.35em] text-emerald-200/70">Crew Level</p>
+                      <p className="mt-2 text-2xl font-semibold text-white">Legendary</p>
+                      <p className="mt-2 text-xs text-emerald-100/60">5-tier orchard boosters unlocked</p>
+                    </div>
+                    <div className="rounded-3xl border border-white/10 bg-white/5 p-5 text-sm text-emerald-100/80">
+                      <p className="text-xs uppercase tracking-[0.35em] text-emerald-200/70">Daily Harvest</p>
+                      <p className="mt-2 text-2xl font-semibold text-white">642 P-Coins</p>
+                      <p className="mt-2 text-xs text-emerald-100/60">Auto-credited to vault wallet</p>
+                    </div>
+                  </div>
+
+                  <div className="rounded-3xl border border-emerald-400/30 bg-gradient-to-r from-emerald-500/20 to-amber-400/20 p-6 text-sm text-emerald-50/90">
+                    <p className="text-xs uppercase tracking-[0.35em] text-emerald-200/70">Referral Streak</p>
+                    <p className="mt-2 text-xl font-semibold text-white">Team Orchard: 48 active growers</p>
+                    <p className="mt-3 text-xs text-emerald-100/60">
+                      Harvest synergy bonus active • Next milestone unlocks +3% yield amplification.
+                    </p>
+                  </div>
+                </div>
+              </div>
             </div>
-            <h3 className="text-xl font-semibold">Easy Mining</h3>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Simple one-click mining with daily rewards and automated profit distribution.
-            </p>
           </div>
-          <div className="group rounded-3xl border border-border/60 bg-card/80 p-6 shadow-lg shadow-primary/10 transition-all hover:-translate-y-1 hover:border-primary/60 hover:shadow-primary/30">
-            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-accent text-primary-foreground shadow-lg shadow-primary/30">
-              <Users className="h-8 w-8" />
+        </section>
+
+        <section className="container mx-auto px-4 pb-24">
+          <div className="grid gap-12 lg:grid-cols-3">
+            {featureHighlights.map((feature) => (
+              <div
+                key={feature.title}
+                className="group relative overflow-hidden rounded-[2rem] border border-white/10 bg-white/5 p-8 transition-transform duration-300 hover:-translate-y-2 hover:bg-white/10"
+              >
+                <div className="absolute -right-10 -top-10 h-32 w-32 rounded-full bg-emerald-400/10 blur-2xl transition-opacity group-hover:opacity-100" />
+                <feature.icon className="h-10 w-10 text-emerald-300" />
+                <h3 className="mt-6 text-2xl font-semibold text-white">{feature.title}</h3>
+                <p className="mt-4 text-sm text-emerald-100/70">{feature.description}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="border-t border-white/5 bg-white/[0.02]">
+          <div className="container mx-auto grid gap-12 px-4 py-20 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+            <div className="space-y-6">
+              <h2 className="text-3xl font-bold text-white sm:text-4xl">Your Apple Mine journey</h2>
+              <p className="text-emerald-100/70">
+                Designed for clarity, the Apple Mine flow guides you from onboarding to consistent harvesting with cinematic
+                visuals and precise metrics.
+              </p>
+              <Link href="/auth/register">
+                <Button variant="outline" className="rounded-full border-emerald-400/40 bg-transparent px-8 py-6 text-emerald-100 hover:bg-emerald-400/10">
+                  Explore the onboarding ritual
+                </Button>
+              </Link>
             </div>
-            <h3 className="text-xl font-semibold">Team Building</h3>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Build your network with referral rewards and multi-level commission structure.
-            </p>
-          </div>
-          <div className="group rounded-3xl border border-border/60 bg-card/80 p-6 shadow-lg shadow-primary/10 transition-all hover:-translate-y-1 hover:border-primary/60 hover:shadow-primary/30">
-            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-accent text-primary-foreground shadow-lg shadow-primary/30">
-              <Shield className="h-8 w-8" />
+            <div className="space-y-6">
+              {journeySteps.map((step, index) => (
+                <div key={step.title} className="relative rounded-3xl border border-white/8 bg-white/6 p-6">
+                  <div className="absolute -left-6 top-6 flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-emerald-400 via-lime-400 to-amber-300 text-base font-semibold text-emerald-950 shadow-lg">
+                    0{index + 1}
+                  </div>
+                  <div className="ml-10">
+                    <h3 className="text-xl font-semibold text-white">{step.title}</h3>
+                    <p className="mt-2 text-sm text-emerald-100/70">{step.detail}</p>
+                  </div>
+                </div>
+              ))}
             </div>
-            <h3 className="text-xl font-semibold">Secure Platform</h3>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Advanced security measures with transparent transaction tracking and admin oversight.
-            </p>
           </div>
-        </div>
+        </section>
+
+        <section className="container mx-auto px-4 pb-28 pt-16">
+          <div className="relative overflow-hidden rounded-[3rem] border border-emerald-400/30 bg-gradient-to-br from-emerald-500/20 via-emerald-400/15 to-amber-400/25 p-10 text-center shadow-[0_30px_60px_rgba(34,197,94,0.25)]">
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.15),_transparent_60%)]" />
+            <div className="relative space-y-6">
+              <h2 className="text-3xl font-bold text-white sm:text-4xl">
+                Ready to cultivate a brilliant mining orchard?
+              </h2>
+              <p className="mx-auto max-w-2xl text-base text-emerald-100/80">
+                Apple Mine fuses handcrafted aesthetics with resilient infrastructure. Join thousands of orchard pioneers who
+                mine together, strategize together, and grow together.
+              </p>
+              <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+                <Link href="/auth/register">
+                  <Button size="lg" className="h-14 rounded-full bg-gradient-to-r from-emerald-400 via-lime-400 to-amber-300 px-10 text-base font-semibold text-emerald-950">
+                    Create account
+                  </Button>
+                </Link>
+                <Link href="/auth/login">
+                  <Button size="lg" variant="outline" className="h-14 rounded-full border-white/40 bg-white/10 px-10 text-base text-white hover:bg-white/20">
+                    Access my orchard
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
       </main>
     </div>
   )

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -154,7 +154,7 @@ export default function SupportPage() {
                     <Mail className="w-5 h-5 text-muted-foreground" />
                     <div>
                       <p className="font-medium">Email Support</p>
-                      <p className="text-sm text-muted-foreground">Mintminepro@gmail.com</p>
+                      <p className="text-sm text-muted-foreground">support@applemine.co</p>
                     </div>
                   </div>
 

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -53,7 +53,7 @@ export default function TermsPage() {
               </CardHeader>
               <CardContent className="prose prose-sm max-w-none">
                 <p>
-                  By accessing and using Mintmine Pro ("the Platform"), you accept and agree to be bound by the terms
+                  By accessing and using Apple Mine ("the Platform"), you accept and agree to be bound by the terms
                   and provision of this agreement. If you do not agree to abide by the above, please do not use this
                   service.
                 </p>
@@ -65,7 +65,7 @@ export default function TermsPage() {
                 <CardTitle>2. Platform Description</CardTitle>
               </CardHeader>
               <CardContent className="prose prose-sm max-w-none">
-                <p>Mintmine Pro is a cryptocurrency mining and investment platform that allows users to:</p>
+                <p>Apple Mine is a cryptocurrency mining and investment platform that allows users to:</p>
                 <ul className="list-disc pl-6 space-y-1">
                   <li>Participate in P-Coin mining activities</li>
                   <li>Stake cryptocurrencies for rewards</li>
@@ -178,7 +178,7 @@ export default function TermsPage() {
               </CardHeader>
               <CardContent className="prose prose-sm max-w-none">
                 <p>
-                  Mintmine Pro shall not be liable for any direct, indirect, incidental, special, or consequential
+                  Apple Mine shall not be liable for any direct, indirect, incidental, special, or consequential
                   damages resulting from the use or inability to use the platform, even if advised of the possibility of
                   such damages.
                 </p>

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -94,14 +94,19 @@ export function LoginForm() {
   }
 
   return (
-    <div className="w-full max-w-lg overflow-hidden rounded-3xl border border-border/70 bg-card shadow-xl shadow-primary/10 transition-colors">
-      <div className="bg-gradient-to-r from-primary to-accent py-4 text-center text-primary-foreground">
-        <h1 className="text-lg font-semibold tracking-wide">User Referral Login System</h1>
+    <div className="w-full overflow-hidden rounded-[2.5rem] border border-white/10 bg-black/60 shadow-[0_25px_60px_rgba(14,116,144,0.35)]">
+      <div className="relative overflow-hidden px-10 py-10 text-center text-emerald-950">
+        <div className="absolute inset-0 bg-gradient-to-r from-emerald-400/80 via-lime-400/60 to-amber-300/60" />
+        <div className="relative space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-emerald-950/80">Welcome Back</p>
+          <h1 className="text-2xl font-bold uppercase tracking-[0.2em]">Apple Mine Gateway</h1>
+          <p className="text-sm font-medium text-emerald-950/80">Sign in to reignite your orchard-grade mining pods</p>
+        </div>
       </div>
 
-      <div className="space-y-6 px-6 py-6 sm:px-8">
+      <div className="space-y-6 px-8 py-8 sm:px-10">
         <div className="flex justify-center">
-          <div className="flex h-14 w-14 items-center justify-center rounded-full border border-border/60 bg-background/80 text-primary shadow-sm">
+          <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-emerald-400/40 bg-emerald-400/15 text-emerald-200 shadow-[0_15px_30px_rgba(34,197,94,0.25)]">
             <UserRoundPlus className="h-8 w-8" />
           </div>
         </div>
@@ -121,35 +126,45 @@ export function LoginForm() {
             }}
             className="space-y-4"
           >
-            <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="email">Email</TabsTrigger>
-              <TabsTrigger value="phone">Phone</TabsTrigger>
+            <TabsList className="grid w-full grid-cols-2 rounded-full bg-emerald-500/10 p-1">
+              <TabsTrigger
+                value="email"
+                className="rounded-full text-sm font-semibold data-[state=active]:bg-emerald-400 data-[state=active]:text-emerald-950"
+              >
+                Email
+              </TabsTrigger>
+              <TabsTrigger
+                value="phone"
+                className="rounded-full text-sm font-semibold data-[state=active]:bg-emerald-400 data-[state=active]:text-emerald-950"
+              >
+                Phone
+              </TabsTrigger>
             </TabsList>
 
             <TabsContent value="email" className="space-y-2">
-              <Label htmlFor="email" className="text-sm font-semibold text-foreground/90">
+              <Label htmlFor="email" className="text-sm font-semibold text-emerald-100/90">
                 Email Address
               </Label>
               <Input
                 id="email"
                 type="email"
-                placeholder="Enter your email"
+                placeholder="enter@email.com"
                 value={formData.email}
                 onChange={(event) => setFormData((prev) => ({ ...prev, email: event.target.value }))}
-                className="h-11"
+                className="h-12 rounded-xl border-emerald-400/30 bg-black/40"
               />
             </TabsContent>
 
             <TabsContent value="phone" className="space-y-2">
-              <Label htmlFor="phone" className="text-sm font-semibold text-foreground/90">
+              <Label htmlFor="phone" className="text-sm font-semibold text-emerald-100/90">
                 Phone Number
               </Label>
-              <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                 <Select
                   value={formData.countryCode}
                   onValueChange={(value) => setFormData((prev) => ({ ...prev, countryCode: value }))}
                 >
-                  <SelectTrigger className="h-11 rounded-md sm:w-40">
+                  <SelectTrigger className="h-12 rounded-xl border-emerald-400/30 bg-black/40 sm:w-40">
                     <SelectValue placeholder="Country" />
                   </SelectTrigger>
                   <SelectContent className="max-h-64">
@@ -168,17 +183,17 @@ export function LoginForm() {
                   onChange={(event) =>
                     setFormData((prev) => ({ ...prev, phone: event.target.value.replace(/[^\d]/g, "") }))
                   }
-                  className="h-11 flex-1"
+                  className="h-12 flex-1 rounded-xl border-emerald-400/30 bg-black/40"
                 />
               </div>
-              <p className="text-xs text-muted-foreground">
+              <p className="text-xs text-emerald-100/70">
                 Use the number you registered with, including the country code.
               </p>
             </TabsContent>
           </Tabs>
 
           <div className="space-y-2">
-            <Label htmlFor="password" className="text-sm font-semibold text-foreground/90">
+            <Label htmlFor="password" className="text-sm font-semibold text-emerald-100/90">
               Password
             </Label>
             <Input
@@ -188,35 +203,41 @@ export function LoginForm() {
               value={formData.password}
               onChange={(event) => setFormData((prev) => ({ ...prev, password: event.target.value }))}
               required
-              className="h-11"
+              className="h-12 rounded-xl border-emerald-400/30 bg-black/40"
             />
           </div>
 
           <div className="flex items-center justify-end text-sm">
             <Link
               href="/auth/forgot"
-              className="font-medium text-primary underline-offset-4 transition-colors hover:text-primary/80 hover:underline"
+              className="font-medium text-emerald-300 underline-offset-4 transition-colors hover:text-emerald-200 hover:underline"
             >
               Forgot Password?
             </Link>
           </div>
 
-          <div className="flex flex-col sm:flex-row gap-3">
-            <Button type="button" variant="outline" className="flex-1 h-11" onClick={() => router.push("/auth/register")}>
-              (Create Account)
-            </Button>
-            <Button type="submit" className="flex-1 h-11 shadow-lg shadow-primary/20" disabled={isLoading}>
-              {isLoading ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Logging in...
-                </>
-              ) : (
-                "Login"
-              )}
-            </Button>
-          </div>
+          <Button
+            type="submit"
+            className="h-12 w-full rounded-xl bg-gradient-to-r from-emerald-400 via-lime-400 to-amber-300 text-base font-semibold text-emerald-950 shadow-[0_20px_40px_rgba(34,197,94,0.25)] hover:from-emerald-300 hover:via-lime-300 hover:to-amber-200"
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Signing In...
+              </>
+            ) : (
+              "Enter Dashboard"
+            )}
+          </Button>
         </form>
+
+        <div className="rounded-2xl border border-emerald-400/25 bg-emerald-400/10 p-5 text-center text-sm text-emerald-100/80">
+          New to Apple Mine?{" "}
+          <Link href="/auth/register" className="font-semibold text-emerald-200 underline-offset-4 hover:underline">
+            Create an account
+          </Link>
+        </div>
       </div>
     </div>
   )

--- a/components/auth/otp-verification.tsx
+++ b/components/auth/otp-verification.tsx
@@ -6,7 +6,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp"
 import { Loader2, Mail, Smartphone, RefreshCw } from "lucide-react"
-import Image from "next/image"
 
 interface OTPVerificationProps {
   email?: string
@@ -97,16 +96,17 @@ export default function OTPVerification({ email, phone, onVerified, onBack }: OT
   }
 
   return (
-    <Card className="w-full max-w-md">
-      <CardHeader className="text-center">
-        <div className="mx-auto mb-4 w-16 h-16 relative">
-          <Image src="/images/mintmine-logo.png" alt="Mintmine Pro" fill className="object-contain" />
+    <Card className="w-full max-w-md overflow-hidden rounded-[2rem] border border-white/10 bg-black/60 shadow-[0_20px_45px_rgba(34,197,94,0.25)]">
+      <CardHeader className="relative space-y-3 text-center">
+        <div className="absolute inset-0 -z-10 bg-gradient-to-r from-emerald-400/20 via-lime-400/10 to-amber-300/20" />
+        <div className="mx-auto mt-4 flex h-16 w-16 items-center justify-center rounded-2xl border border-emerald-400/40 bg-emerald-400/15 text-3xl">
+          🍏
         </div>
-        <CardTitle className="text-2xl font-bold">Verify Your Account</CardTitle>
-        <CardDescription>
+        <CardTitle className="text-2xl font-bold text-white">Confirm Your Apple Mine Identity</CardTitle>
+        <CardDescription className="text-emerald-100/80">
           We've sent a 6-digit code to {email ? "your email" : "your phone"}
           <br />
-          <span className="font-medium text-foreground">{email || phone}</span>
+          <span className="font-medium text-white/90">{email || phone}</span>
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -119,18 +119,22 @@ export default function OTPVerification({ email, phone, onVerified, onBack }: OT
         <div className="space-y-4">
           <div className="flex justify-center">
             <InputOTP maxLength={6} value={otp} onChange={(value) => setOtp(value)}>
-              <InputOTPGroup>
-                <InputOTPSlot index={0} />
-                <InputOTPSlot index={1} />
-                <InputOTPSlot index={2} />
-                <InputOTPSlot index={3} />
-                <InputOTPSlot index={4} />
-                <InputOTPSlot index={5} />
+              <InputOTPGroup className="gap-3">
+                <InputOTPSlot index={0} className="h-14 w-12 rounded-xl border-emerald-400/40 bg-black/40 text-xl" />
+                <InputOTPSlot index={1} className="h-14 w-12 rounded-xl border-emerald-400/40 bg-black/40 text-xl" />
+                <InputOTPSlot index={2} className="h-14 w-12 rounded-xl border-emerald-400/40 bg-black/40 text-xl" />
+                <InputOTPSlot index={3} className="h-14 w-12 rounded-xl border-emerald-400/40 bg-black/40 text-xl" />
+                <InputOTPSlot index={4} className="h-14 w-12 rounded-xl border-emerald-400/40 bg-black/40 text-xl" />
+                <InputOTPSlot index={5} className="h-14 w-12 rounded-xl border-emerald-400/40 bg-black/40 text-xl" />
               </InputOTPGroup>
             </InputOTP>
           </div>
 
-          <Button onClick={handleVerify} className="w-full" disabled={isLoading || otp.length !== 6}>
+          <Button
+            onClick={handleVerify}
+            className="h-12 w-full rounded-xl bg-gradient-to-r from-emerald-400 via-lime-400 to-amber-300 text-base font-semibold text-emerald-950 shadow-[0_12px_24px_rgba(34,197,94,0.25)] hover:from-emerald-300 hover:via-lime-300 hover:to-amber-200"
+            disabled={isLoading || otp.length !== 6}
+          >
             {isLoading ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -142,9 +146,14 @@ export default function OTPVerification({ email, phone, onVerified, onBack }: OT
           </Button>
         </div>
 
-        <div className="text-center space-y-2">
-          <p className="text-sm text-muted-foreground">Didn't receive the code?</p>
-          <Button variant="ghost" onClick={handleResend} disabled={!canResend || isResending} className="text-sm">
+        <div className="space-y-2 text-center">
+          <p className="text-sm text-emerald-100/70">Didn't receive the code?</p>
+          <Button
+            variant="ghost"
+            onClick={handleResend}
+            disabled={!canResend || isResending}
+            className="text-sm text-emerald-200 hover:text-emerald-100"
+          >
             {isResending ? (
               <>
                 <RefreshCw className="mr-2 h-3 w-3 animate-spin" />
@@ -160,8 +169,11 @@ export default function OTPVerification({ email, phone, onVerified, onBack }: OT
             )}
           </Button>
         </div>
-
-        <Button variant="outline" onClick={onBack} className="w-full bg-transparent">
+        <Button
+          variant="outline"
+          onClick={onBack}
+          className="h-12 w-full rounded-xl border-emerald-400/40 bg-transparent text-emerald-100 hover:bg-emerald-400/10"
+        >
           Back to Registration
         </Button>
       </CardContent>

--- a/components/auth/register-form.tsx
+++ b/components/auth/register-form.tsx
@@ -225,15 +225,24 @@ export function RegisterForm() {
     }
   }
 
+  const inputClasses = "h-12 rounded-xl border-emerald-400/30 bg-black/40"
+
   return (
-    <div className="w-full max-w-2xl overflow-hidden rounded-3xl border border-border/70 bg-card shadow-xl shadow-primary/10 transition-colors">
-      <div className="bg-gradient-to-r from-primary to-accent py-4 text-center text-primary-foreground">
-        <h1 className="text-lg font-semibold tracking-wide">Referral Signup System</h1>
+    <div className="w-full max-w-3xl overflow-hidden rounded-[2.75rem] border border-white/10 bg-black/60 shadow-[0_25px_80px_rgba(34,197,94,0.22)]">
+      <div className="relative overflow-hidden px-10 py-10 text-center text-emerald-950">
+        <div className="absolute inset-0 bg-gradient-to-r from-emerald-400/80 via-lime-400/60 to-amber-300/60" />
+        <div className="relative space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-950/80">Ignite your orchard identity</p>
+          <h1 className="text-2xl font-bold uppercase tracking-[0.2em]">Apple Mine Enrollment</h1>
+          <p className="text-sm font-medium text-emerald-950/80">
+            Set up your Apple Mine profile to unlock collaborative orchard mining and layered rewards
+          </p>
+        </div>
       </div>
 
-      <div className="space-y-6 px-6 py-6 sm:px-8">
+      <div className="space-y-6 px-8 py-10 sm:px-12">
         <div className="flex justify-center">
-          <div className="flex h-14 w-14 items-center justify-center rounded-full border border-border/60 bg-background/80 text-primary shadow-sm">
+          <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-emerald-400/40 bg-emerald-400/15 text-emerald-200 shadow-[0_15px_30px_rgba(34,197,94,0.25)]">
             <UserPlus className="h-8 w-8" />
           </div>
         </div>
@@ -245,15 +254,15 @@ export function RegisterForm() {
         )}
 
         {infoMessage && (
-          <Alert>
+          <Alert className="border-emerald-400/40 bg-emerald-400/10 text-emerald-100">
             <AlertDescription>{infoMessage}</AlertDescription>
           </Alert>
         )}
 
-        <form onSubmit={handleSubmit} className="space-y-5">
+        <form onSubmit={handleSubmit} className="space-y-6">
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
-              <Label htmlFor="name" className="text-sm font-semibold text-foreground/90">
+              <Label htmlFor="name" className="text-sm font-semibold text-emerald-100/90">
                 Name
               </Label>
               <Input
@@ -267,12 +276,13 @@ export function RegisterForm() {
                   }
                 }}
                 required
-                className="h-11"
+                className={inputClasses}
+                disabled={step === "otp"}
               />
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="email" className="text-sm font-semibold text-foreground/90">
+              <Label htmlFor="email" className="text-sm font-semibold text-emerald-100/90">
                 Email
               </Label>
               <Input
@@ -287,14 +297,14 @@ export function RegisterForm() {
                   }
                 }}
                 required
-                className="h-11"
+                className={inputClasses}
                 disabled={step === "otp"}
               />
             </div>
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="phone" className="text-sm font-semibold text-foreground/90">
+            <Label htmlFor="phone" className="text-sm font-semibold text-emerald-100/90">
               Phone Number
             </Label>
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -308,7 +318,7 @@ export function RegisterForm() {
                 }}
                 disabled={step === "otp"}
               >
-                <SelectTrigger className="h-11 rounded-md sm:w-40">
+                <SelectTrigger className={`${inputClasses} sm:w-40`}>
                   <SelectValue placeholder="Country" />
                 </SelectTrigger>
                 <SelectContent className="max-h-64">
@@ -332,18 +342,16 @@ export function RegisterForm() {
                   }
                 }}
                 required
-                className="h-11 flex-1"
+                className={`${inputClasses} flex-1`}
                 disabled={step === "otp"}
               />
             </div>
-            <p className="text-xs text-muted-foreground">
-              Include your full phone number. Country code is added automatically.
-            </p>
+            <p className="text-xs text-emerald-100/70">Include your full phone number. Country code is added automatically.</p>
           </div>
 
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
-              <Label htmlFor="password" className="text-sm font-semibold text-foreground/90">
+              <Label htmlFor="password" className="text-sm font-semibold text-emerald-100/90">
                 Password
               </Label>
               <Input
@@ -359,13 +367,13 @@ export function RegisterForm() {
                 }}
                 required
                 minLength={6}
-                className="h-11"
+                className={inputClasses}
                 disabled={step === "otp"}
               />
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="confirmPassword" className="text-sm font-semibold text-foreground/90">
+              <Label htmlFor="confirmPassword" className="text-sm font-semibold text-emerald-100/90">
                 Re-enter Password
               </Label>
               <Input
@@ -381,14 +389,14 @@ export function RegisterForm() {
                 }}
                 required
                 minLength={6}
-                className="h-11"
+                className={inputClasses}
                 disabled={step === "otp"}
               />
             </div>
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="referralCode" className="text-sm font-semibold text-foreground/90">
+            <Label htmlFor="referralCode" className="text-sm font-semibold text-emerald-100/90">
               Referral Code
             </Label>
             <Input
@@ -403,27 +411,26 @@ export function RegisterForm() {
                 }
               }}
               required
+              className={inputClasses}
               disabled={step === "otp"}
             />
           </div>
 
           {step === "otp" && (
-            <div className="space-y-3">
+            <div className="rounded-3xl border border-emerald-400/25 bg-emerald-400/10 p-6">
               <div className="space-y-2 text-center">
-                <Label className="text-sm font-semibold text-foreground/90">Enter the 6-digit code</Label>
+                <Label className="text-sm font-semibold text-emerald-100/90">Enter the 6-digit code</Label>
                 <OTPInput value={otpValue} onChange={setOtpValue} disabled={isLoading} />
               </div>
-              <div className="flex flex-col items-center justify-center gap-2 text-xs text-muted-foreground sm:flex-row">
-                <span>
-                  {otpCountdown > 0 ? `You can request a new code in ${otpCountdown}s` : "Didn't get the code?"}
-                </span>
+              <div className="mt-4 flex flex-col items-center justify-center gap-2 text-xs text-emerald-100/70 sm:flex-row">
+                <span>{otpCountdown > 0 ? `You can request a new code in ${otpCountdown}s` : "Didn't get the code?"}</span>
                 <Button
                   type="button"
                   variant="ghost"
                   size="sm"
                   onClick={handleResendOTP}
                   disabled={isResending || otpCountdown > 0}
-                  className="h-8 px-2"
+                  className="h-8 px-3 text-emerald-200 hover:text-emerald-100"
                 >
                   {isResending ? (
                     <>
@@ -438,13 +445,22 @@ export function RegisterForm() {
           )}
 
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            {step === "details" && (
-              <Button type="button" variant="outline" className="h-11 sm:w-auto" onClick={() => router.push("/auth/forgot")}>
-                Forgot Password?
-              </Button>
+            {step === "details" ? (
+              <Link
+                href="/auth/forgot"
+                className="text-sm font-semibold text-emerald-200 underline-offset-4 hover:text-emerald-100 hover:underline"
+              >
+                Need to reset your password?
+              </Link>
+            ) : (
+              <p className="text-sm text-emerald-100/70">Check your inbox for the Apple Mine verification code.</p>
             )}
 
-            <Button type="submit" className="h-11 flex-1 sm:flex-none shadow-lg shadow-primary/20" disabled={isLoading}>
+            <Button
+              type="submit"
+              className="h-12 flex-1 rounded-xl bg-gradient-to-r from-emerald-400 via-lime-400 to-amber-300 text-base font-semibold text-emerald-950 shadow-[0_20px_40px_rgba(34,197,94,0.25)] hover:from-emerald-300 hover:via-lime-300 hover:to-amber-200 sm:flex-none sm:px-8"
+              disabled={isLoading}
+            >
               {isLoading ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -459,9 +475,9 @@ export function RegisterForm() {
           </div>
         </form>
 
-        <p className="text-center text-sm text-muted-foreground">
-          Already have an account?{" "}
-          <Link href="/auth/login" className="font-semibold text-primary hover:underline">
+        <p className="text-center text-sm text-emerald-100/70">
+          Already cultivating with Apple Mine?{" "}
+          <Link href="/auth/login" className="font-semibold text-emerald-200 underline-offset-4 hover:underline">
             Login instead
           </Link>
         </p>

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -7,7 +7,6 @@ import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { NotificationBell } from "@/components/notifications/notification-bell"
 import { ThemeToggle } from "@/components/theme-toggle"
-import Image from "next/image"
 import {
   Home,
   BarChart3,
@@ -71,9 +70,14 @@ export function Sidebar({ user }: SidebarProps) {
     <div className="flex h-full flex-col bg-sidebar">
       {/* Logo */}
       <div className="flex h-16 items-center justify-between border-b border-sidebar-border px-6">
-        <div className="flex items-center space-x-2">
-          <Image src="/images/logo.png" alt="Mintmine Pro" width={32} height={32} className="rounded-lg" />
-          <span className="text-lg font-bold text-sidebar-foreground">Mintmine Pro</span>
+        <div className="flex items-center space-x-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-emerald-400 via-lime-400 to-amber-300 text-lg font-bold text-emerald-900 shadow-[0_10px_25px_rgba(34,197,94,0.25)]">
+            🍏
+          </div>
+          <div>
+            <span className="text-lg font-bold text-sidebar-foreground">Apple Mine</span>
+            <p className="text-xs font-medium uppercase tracking-[0.35em] text-sidebar-foreground/70">Orchard Network</p>
+          </div>
         </div>
         <div className="md:hidden mt-2 flex items-center gap-2">
           <NotificationBell />

--- a/lib/utils/constants.ts
+++ b/lib/utils/constants.ts
@@ -1,9 +1,9 @@
 // Application constants
 export const APP_CONFIG = {
-  name: "Mintmine Pro",
-  description: "Advanced cryptocurrency mining platform",
+  name: "Apple Mine",
+  description: "Orchard-inspired cryptocurrency mining collective",
   version: "1.0.0",
-  supportEmail: "Mintminepro@gmail.com",
+  supportEmail: "support@applemine.co",
   maxFileSize: 5 * 1024 * 1024, // 5MB
   allowedImageTypes: ["image/jpeg", "image/png", "image/webp"],
 } as const

--- a/lib/utils/email.tsx
+++ b/lib/utils/email.tsx
@@ -18,7 +18,7 @@ export async function sendOTPEmail(email: string, otp: string, purpose = "regist
   }
 
   const transporter = createTransporter()
-  const subject = `Your Mintmine Pro Verification Code`
+  const subject = `Your Apple Mine Verification Code`
 
   const html = `
     <!DOCTYPE html>
@@ -29,13 +29,13 @@ export async function sendOTPEmail(email: string, otp: string, purpose = "regist
     </head>
     <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
       <div style="text-align: center; margin-bottom: 30px;">
-        <div style="background: #f59e0b; color: white; width: 60px; height: 60px; border-radius: 12px; display: inline-flex; align-items: center; justify-content: center; font-size: 24px; font-weight: bold;">
-          M
+        <div style="background: linear-gradient(135deg, #4ade80, #a3e635, #facc15); color: #064e3b; width: 64px; height: 64px; border-radius: 16px; display: inline-flex; align-items: center; justify-content: center; font-size: 28px; font-weight: bold;">
+          🍏
         </div>
       </div>
       
       <div style="background: #f8f9fa; padding: 30px; border-radius: 10px; text-align: center;">
-        <h2 style="color: #1e40af; margin-bottom: 20px;">Verification Code</h2>
+        <h2 style="color: #047857; margin-bottom: 20px;">Apple Mine Verification Code</h2>
         <p style="font-size: 16px; color: #374151; margin-bottom: 25px;">
           Your verification code for ${purpose} is:
         </p>
@@ -46,9 +46,9 @@ export async function sendOTPEmail(email: string, otp: string, purpose = "regist
           This code will expire in 10 minutes. Do not share this code with anyone.
         </p>
       </div>
-      
+
       <div style="text-align: center; margin-top: 30px; font-size: 12px; color: #9ca3af;">
-        <p>© 2025 Mintmine Pro. All rights reserved.</p>
+        <p>© 2025 Apple Mine. All rights reserved.</p>
       </div>
     </body>
     </html>
@@ -56,7 +56,7 @@ export async function sendOTPEmail(email: string, otp: string, purpose = "regist
 
   try {
     await transporter.sendMail({
-      from: `"Mintmine Pro" <${process.env.SMTP_USER}>`,
+      from: `"Apple Mine" <${process.env.SMTP_USER}>`,
       to: email,
       subject,
       html,

--- a/lib/utils/sms.ts
+++ b/lib/utils/sms.ts
@@ -8,7 +8,7 @@ export async function sendOTPSMS(phone: string, otp: string, purpose = "registra
   }
 
   const client = twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN)
-  const message = `Your Mintmine Pro verification code for ${purpose} is: ${otp}. This code expires in 10 minutes. Do not share this code.`
+  const message = `Your Apple Mine verification code for ${purpose} is: ${otp}. This code expires in 10 minutes. Do not share this code.`
 
   try {
     await client.messages.create({


### PR DESCRIPTION
## Summary
- refresh the public landing page with an Apple Mine orchard aesthetic, expanded storytelling sections, and new CTA flows
- update authentication experiences, verification screens, and shared layout elements to match the new brand palette and typography
- rename platform references, constants, and support details to the Apple Mine identity across metadata, terms, and utilities

## Testing
- `npm run lint` *(cancelled – command prompted for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68e0629d328883279a31fdd334d3f252