### PR TITLE
Revise reward distribution and dashboard metrics

### DIFF
--- a/app/api/admin/approve-deposit/route.ts
+++ b/app/api/admin/approve-deposit/route.ts
@@ -5,7 +5,7 @@ import Balance from "@/models/Balance"
 import Transaction from "@/models/Transaction"
 import Notification from "@/models/Notification"
 import { getUserFromRequest } from "@/lib/auth"
-import { processReferralCommission } from "@/lib/utils/commission"
+import { applyDepositRewards } from "@/lib/utils/commission"
 
 export async function POST(request: NextRequest) {
   try {
@@ -46,8 +46,8 @@ export async function POST(request: NextRequest) {
       ),
     ])
 
-    // Process referral commission
-    await processReferralCommission(transaction.userId.toString(), transaction.amount)
+    // Apply deposit commissions and referral rewards
+    await applyDepositRewards(transaction.userId.toString(), transaction.amount)
 
     // Create notification
     await Notification.create({

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -55,8 +55,8 @@ export async function GET(request: NextRequest) {
 
     const teamRewardsAvailable = balance.teamRewardsAvailable ?? 0
     const totalEarning = balance.totalEarning ?? 0
-    const totalBalance = (balance.totalBalance ?? 0) + teamRewardsAvailable
-    const currentBalance = (balance.current ?? 0) + teamRewardsAvailable
+    const totalBalance = balance.totalBalance ?? 0
+    const currentBalance = balance.current ?? 0
 
     return NextResponse.json({
       kpis: {

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -5,7 +5,7 @@ import { KPICards } from "@/components/dashboard/kpi-cards"
 import { MiningWidget } from "@/components/dashboard/mining-widget"
 import { HalvingChart } from "@/components/dashboard/halving-chart"
 import { Sidebar } from "@/components/layout/sidebar"
-import { Loader2, TrendingUp, Users, Wallet } from "lucide-react"
+import { Loader2, Users, Wallet } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
 interface DashboardData {
@@ -103,18 +103,7 @@ export default function DashboardPage() {
             <HalvingChart />
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <Card className="crypto-card">
-              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">Mining Level</CardTitle>
-                <TrendingUp className="h-4 w-4 text-muted-foreground" />
-              </CardHeader>
-              <CardContent>
-                <div className="text-3xl font-bold crypto-gradient-text">Level {data.user.level}</div>
-                <p className="text-xs text-muted-foreground mt-1">Professional Miner Status</p>
-              </CardContent>
-            </Card>
-
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <Card className="crypto-card">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">ROI Progress</CardTitle>

--- a/components/dashboard/kpi-cards.tsx
+++ b/components/dashboard/kpi-cards.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { TrendingUp, Wallet, DollarSign, Users, ArrowDownToLine, Clock, Trophy } from "lucide-react"
+import { TrendingUp, Wallet, DollarSign, ArrowDownToLine, Clock, Trophy } from "lucide-react"
 
 interface KPICardsProps {
   kpis: {
@@ -39,13 +39,6 @@ export function KPICards({ kpis }: KPICardsProps) {
       icon: DollarSign,
       color: "text-amber-600",
       bgColor: "bg-amber-50",
-    },
-    {
-      title: "Active Members",
-      value: kpis.activeMembers.toString(),
-      icon: Users,
-      color: "text-purple-600",
-      bgColor: "bg-purple-50",
     },
     {
       title: "Total Withdraw",

--- a/lib/services/deposit.ts
+++ b/lib/services/deposit.ts
@@ -10,7 +10,7 @@ import Balance from "@/models/Balance"
 import Transaction from "@/models/Transaction"
 import Notification from "@/models/Notification"
 import { depositSchema } from "@/lib/validations/wallet"
-import { calculateUserLevel, processReferralCommission } from "@/lib/utils/commission"
+import { applyDepositRewards } from "@/lib/utils/commission"
 
 const FAKE_DEPOSIT_AMOUNT = 30
 const TEST_TRANSACTION_NUMBER = "FAKE-DEPOSIT-12345"
@@ -195,8 +195,7 @@ export async function submitDeposit(input: DepositSubmissionInput) {
       ),
     ])
 
-    await processReferralCommission(input.userId, FAKE_DEPOSIT_AMOUNT)
-    await calculateUserLevel(input.userId)
+    await applyDepositRewards(input.userId, FAKE_DEPOSIT_AMOUNT)
 
     await Notification.create({
       userId: input.userId,

--- a/lib/services/wallet.ts
+++ b/lib/services/wallet.ts
@@ -34,11 +34,9 @@ export async function fetchWalletContext(userId: string): Promise<WalletContext 
 
   if (!userDoc) return null
 
-  const teamRewardsAvailable = Number(balanceDoc?.teamRewardsAvailable ?? 0)
-
   const stats = {
-    currentBalance: Number(balanceDoc?.current ?? 0) + teamRewardsAvailable,
-    totalBalance: Number(balanceDoc?.totalBalance ?? 0) + teamRewardsAvailable,
+    currentBalance: Number(balanceDoc?.current ?? 0),
+    totalBalance: Number(balanceDoc?.totalBalance ?? 0),
     totalEarning: Number(balanceDoc?.totalEarning ?? 0),
     pendingWithdraw: Number(balanceDoc?.pendingWithdraw ?? 0),
     staked: Number(balanceDoc?.staked ?? 0),

--- a/lib/utils/referral.ts
+++ b/lib/utils/referral.ts
@@ -7,16 +7,13 @@ export function generateReferralCode(): string {
   return result
 }
 
-export function calculateMiningProfit(baseAmount: number, minPct: number, maxPct: number): number {
-  // Use a weighted random distribution favoring middle values
-  const random1 = Math.random()
-  const random2 = Math.random()
-  const weightedRandom = (random1 + random2) / 2 // Creates a bell curve distribution
+export function calculateMiningProfit(baseAmount: number, minPct?: number, maxPct?: number): number {
+  if (baseAmount <= 0) return 0
 
-  const randomPct = weightedRandom * (maxPct - minPct) + minPct
-  const profit = (baseAmount * randomPct) / 100
+  const pct = typeof minPct === "number" && typeof maxPct === "number" ? (minPct + maxPct) / 2 : 2.5
+  const appliedPct = pct || 2.5
+  const profit = (baseAmount * appliedPct) / 100
 
-  // Round to 2 decimal places
   return Math.round(profit * 100) / 100
 }
 
@@ -24,9 +21,10 @@ export function hasReachedROICap(earnedTotal: number, depositTotal: number, roiC
   return earnedTotal >= depositTotal * roiCap
 }
 
-export function calculateEstimatedDailyEarnings(baseAmount: number, minPct: number, maxPct: number): number {
-  const avgPct = (minPct + maxPct) / 2
-  return Math.round(((baseAmount * avgPct) / 100) * 100) / 100
+export function calculateEstimatedDailyEarnings(baseAmount: number, minPct?: number, maxPct?: number): number {
+  if (baseAmount <= 0) return 0
+  const pct = typeof minPct === "number" && typeof maxPct === "number" ? (minPct + maxPct) / 2 : 2.5
+  return Math.round(((baseAmount * (pct || 2.5)) / 100) * 100) / 100
 }
 
 export function calculateROIProgress(earnedTotal: number, depositTotal: number, roiCap: number): number {


### PR DESCRIPTION
## Summary
- implement deposit reward handling that credits a 2% deposit commission, applies the 5-level referral percentages, and accrues team rewards only for deposits of $80 or more
- fix mining payouts to a consistent 2.5% of total deposits per day and stop adding unclaimed team rewards to wallet and dashboard balances so the original values display correctly
- streamline the dashboard cards and ensure admin metrics count every user and pending transaction instead of the limited in-memory sample

## Testing
- not run (npm run lint prompts for an ESLint config)

------
https://chatgpt.com/codex/tasks/task_e_68e2129c1d808327b03589535c20a3ff