### PR TITLE
Implement synchronized launch countdown and quick action menu

### DIFF
--- a/app/api/launch/route.ts
+++ b/app/api/launch/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server"
+
+import { getLaunchSchedule } from "@/lib/services/launch"
+
+export async function GET() {
+  const { launchAt } = getLaunchSchedule()
+  const serverNow = new Date()
+
+  return NextResponse.json(
+    {
+      launch_at: launchAt.toISOString(),
+      server_now: serverNow.toISOString(),
+    },
+    {
+      headers: {
+        "Cache-Control": "no-store, max-age=0",
+      },
+    },
+  )
+}

--- a/app/coins/page.tsx
+++ b/app/coins/page.tsx
@@ -1,12 +1,15 @@
 "use client"
 
-import { FormEvent, useEffect, useState } from "react"
+import { FormEvent, useEffect, useMemo, useState } from "react"
 
 import { Sidebar } from "@/components/layout/sidebar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
+import { Progress } from "@/components/ui/progress"
+import { CountdownBadge, CountdownDisplay } from "@/components/launch/countdown-display"
+import { useLaunchCountdown } from "@/hooks/use-launch-countdown"
 
 interface ListingHighlight {
   title: string
@@ -15,98 +18,140 @@ interface ListingHighlight {
   helper: string
 }
 
-interface UpcomingListing {
+interface ListingCard {
   name: string
   stage: string
   description: string
   launch: string
   interest: string
 }
-
-interface TimeLeft {
-  days: number
-  hours: number
-  minutes: number
-  seconds: number
-}
-
-const LISTING_HIGHLIGHTS: ListingHighlight[] = [
-  {
-    title: "Presales",
-    description: "Curated access to the hottest early-stage token sales.",
-    stat: "12",
-    helper: "Live this quarter",
-  },
-  {
-    title: "Airdrops",
-    description: "Stay ahead with verified reward campaigns and quests.",
-    stat: "28",
-    helper: "Opportunities now",
-  },
-  {
-    title: "DEX/CEX Listings",
-    description: "Track centralized and decentralized launch partners.",
-    stat: "7",
-    helper: "Exchanges confirmed",
-  },
-  {
-    title: "Launchpad",
-    description: "Secure allocations with tiered staking advantages.",
-    stat: "4",
-    helper: "Upcoming cohorts",
-  },
+const INITIAL_SEGMENTS = [
+  { unit: "days", value: 87 },
+  { unit: "hours", value: 59 },
+  { unit: "minutes", value: 59 },
+  { unit: "seconds", value: 59 },
 ]
 
-const UPCOMING_LISTINGS: UpcomingListing[] = [
+const HIGHLIGHTS: Record<"scheduled" | "live", ListingHighlight[]> = {
+  scheduled: [
+    {
+      title: "Presales",
+      description: "Curated access to the hottest early-stage token sales.",
+      stat: "12",
+      helper: "Live this quarter",
+    },
+    {
+      title: "Airdrops",
+      description: "Stay ahead with verified reward campaigns and quests.",
+      stat: "28",
+      helper: "Opportunities now",
+    },
+    {
+      title: "DEX/CEX Listings",
+      description: "Track centralized and decentralized launch partners.",
+      stat: "7",
+      helper: "Exchanges confirmed",
+    },
+    {
+      title: "Launchpad",
+      description: "Secure allocations with tiered staking advantages.",
+      stat: "4",
+      helper: "Upcoming cohorts",
+    },
+  ],
+  live: [
+    {
+      title: "Presales",
+      description: "Allocations unlocked with live on-chain settlement and waitlist auto-fill.",
+      stat: "12",
+      helper: "Now filling",
+    },
+    {
+      title: "Airdrops",
+      description: "Campaign quests are awarding instantly with verified wallet binding.",
+      stat: "31",
+      helper: "Live rewards",
+    },
+    {
+      title: "DEX/CEX Listings",
+      description: "Centralized & decentralized partners are executing liquidity boots.",
+      stat: "9",
+      helper: "Trading",
+    },
+    {
+      title: "Launchpad",
+      description: "Tiered staking bonuses now compounding for live cohorts.",
+      stat: "5",
+      helper: "In-session",
+    },
+  ],
+}
+
+const LISTINGS: ListingCard[] = [
   {
     name: "NebulaX Protocol",
     stage: "Presale",
     description: "AI-enhanced liquidity routing with deflationary tokenomics and governance staking.",
-    launch: "Q3 · 2024",
+    launch: "Liquidity bootstrapping ongoing",
     interest: "18.4k joined",
   },
   {
     name: "HarborFi",
     stage: "DEX Launch",
     description: "Cross-chain stablecoin vaults bringing real-world yield to DeFi users worldwide.",
-    launch: "Q4 · 2024",
+    launch: "Partners confirmed",
     interest: "12.1k joined",
   },
   {
     name: "Arcadia Nodes",
     stage: "Airdrop",
     description: "Validator incentives for powering a privacy-first smart contract network.",
-    launch: "Q1 · 2025",
+    launch: "Questline curated",
     interest: "9.7k joined",
   },
 ]
 
-const MILLISECONDS_IN_SECOND = 1000
-const MILLISECONDS_IN_MINUTE = 60 * MILLISECONDS_IN_SECOND
-const MILLISECONDS_IN_HOUR = 60 * MILLISECONDS_IN_MINUTE
-const MILLISECONDS_IN_DAY = 24 * MILLISECONDS_IN_HOUR
+const ECONOMICS_RULES = [
+  {
+    label: "Minimum Deposit",
+    value: "$80+",
+    scheduled: "Fund your wallet now to auto-qualify when mining opens.",
+    live: "Deposits of $80 or more stay mining-eligible.",
+  },
+  {
+    label: "Deposit Commission",
+    value: "2%",
+    scheduled: "One-time fee held until launch to secure infrastructure.",
+    live: "Applied instantly on new deposits to feed liquidity pools.",
+  },
+  {
+    label: "Daily Mining Yield",
+    value: "2.5%",
+    scheduled: "Projected daily return once hashing begins.",
+    live: "Compounded every cycle and streamed to balances.",
+  },
+  {
+    label: "Team Rewards",
+    value: "Auto-split",
+    scheduled: "Invites accrue credits for Team Earnings and balance unlocks.",
+    live: "Live overrides route straight into Team Earnings and Current Balance.",
+  },
+]
 
-const DEFAULT_LAUNCH_TIMESTAMP = Date.UTC(2025, 0, 15, 0, 0, 0)
-const ENVIRONMENT_LAUNCH_TIMESTAMP = Number(process.env.NEXT_PUBLIC_COIN_LAUNCH_TIMESTAMP ?? 0)
-const COIN_LAUNCH_TIMESTAMP =
-  Number.isFinite(ENVIRONMENT_LAUNCH_TIMESTAMP) && ENVIRONMENT_LAUNCH_TIMESTAMP > 0
-    ? ENVIRONMENT_LAUNCH_TIMESTAMP
-    : DEFAULT_LAUNCH_TIMESTAMP
-
-function calculateTimeLeft(target: number): TimeLeft {
-  const difference = Math.max(target - Date.now(), 0)
-
-  const days = Math.floor(difference / MILLISECONDS_IN_DAY)
-  const hours = Math.floor((difference % MILLISECONDS_IN_DAY) / MILLISECONDS_IN_HOUR)
-  const minutes = Math.floor((difference % MILLISECONDS_IN_HOUR) / MILLISECONDS_IN_MINUTE)
-  const seconds = Math.floor((difference % MILLISECONDS_IN_MINUTE) / MILLISECONDS_IN_SECOND)
-
-  return { days, hours, minutes, seconds }
+const PROGRESS_SNAPSHOTS: Record<"scheduled" | "live", { label: string; value: number; helper: string }[]> = {
+  scheduled: [
+    { label: "Launch readiness", value: 74, helper: "Security audit in review" },
+    { label: "Whitelisted liquidity", value: 58, helper: "Market makers onboarding" },
+  ],
+  live: [
+    { label: "Launch readiness", value: 100, helper: "Platform unlocked" },
+    { label: "Whitelisted liquidity", value: 93, helper: "Depth online" },
+  ],
 }
 
 export default function CoinsPage() {
   const [user, setUser] = useState<any>(null)
-  const [timeLeft, setTimeLeft] = useState<TimeLeft>(() => calculateTimeLeft(COIN_LAUNCH_TIMESTAMP))
+  const { countdown, phase, isReady } = useLaunchCountdown()
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -124,20 +169,20 @@ export default function CoinsPage() {
     fetchUser()
   }, [])
 
-  useEffect(() => {
-    const updateCountdown = () => {
-      setTimeLeft(calculateTimeLeft(COIN_LAUNCH_TIMESTAMP))
-    }
-
-    updateCountdown()
-    const timer = setInterval(updateCountdown, 1000)
-
-    return () => clearInterval(timer)
-  }, [])
-
   const handleJoinWaitlist = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
   }
+
+  const segments = useMemo(() => countdown?.segments ?? INITIAL_SEGMENTS, [countdown])
+  const snapshotKey = phase === "live" ? "live" : "scheduled"
+  const highlightSet = HIGHLIGHTS[snapshotKey]
+  const progressSnapshot = PROGRESS_SNAPSHOTS[snapshotKey]
+
+  const heroBadgeText = phase === "live" ? "Now Live" : "Launching Soon"
+  const heroDescription =
+    phase === "live"
+      ? "Trading, mining, and liquidity programs are open. Secure your allocations and compound from day one."
+      : "Discover upcoming tokens, presales, and exchange listings. We’re finalizing the platform—join the waitlist for day one access and instant alerts."
 
   return (
     <div className="flex min-h-screen bg-gradient-to-br from-background via-background to-muted/30">
@@ -146,16 +191,16 @@ export default function CoinsPage() {
       <main className="flex-1 overflow-auto md:ml-64">
         <div className="px-6 py-12 lg:px-12">
           <div className="mx-auto flex max-w-5xl flex-col items-center text-center">
-            <Badge variant="outline" className="mb-6 border-primary/40 bg-primary/5 text-primary">
-              Launching Soon
+            <Badge
+              variant="outline"
+              className="mb-6 border-primary/40 bg-primary/5 text-primary transition-colors duration-[var(--t-med)] ease-[var(--ease)]"
+            >
+              {heroBadgeText}
             </Badge>
             <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
               Coin Listings &amp; Launchpad
             </h1>
-            <p className="mt-6 max-w-2xl text-balance text-lg text-muted-foreground sm:text-xl">
-              Discover upcoming tokens, presales, and exchange listings. We&apos;re finalizing the platform—join the
-              waitlist for day one access and instant alerts.
-            </p>
+            <p className="mt-6 max-w-2xl text-balance text-lg text-muted-foreground sm:text-xl">{heroDescription}</p>
 
             <form
               onSubmit={handleJoinWaitlist}
@@ -174,43 +219,42 @@ export default function CoinsPage() {
 
             <p className="mt-4 text-sm text-muted-foreground">No spam—just alpha when we go live.</p>
 
-            <div className="mt-10 grid w-full max-w-3xl grid-cols-2 gap-4 sm:grid-cols-4">
-              {Object.entries(timeLeft).map(([label, value]) => (
-                <Card key={label} className="border-muted/50 bg-background/80 shadow-sm backdrop-blur">
-                  <CardContent className="flex flex-col items-center gap-1 py-6">
-                    <span className="text-3xl font-semibold tabular-nums sm:text-4xl">{value.toString().padStart(2, "0")}</span>
-                    <span className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
-                      {label}
-                    </span>
-                  </CardContent>
-                </Card>
-              ))}
+            <div className="mt-10 w-full">
+              <CountdownDisplay segments={segments} phase={phase} />
+              {!isReady && <p className="mt-3 text-xs text-muted-foreground">Syncing launch clock with the network…</p>}
             </div>
           </div>
 
           <div className="mx-auto mt-16 grid max-w-6xl gap-6 lg:grid-cols-[1.2fr_1fr]">
             <div className="space-y-6">
-              {UPCOMING_LISTINGS.map((listing) => (
+              {LISTINGS.map((listing) => (
                 <Card
                   key={listing.name}
                   className="border-muted/60 bg-background/90 shadow-sm transition-colors hover:border-primary/40 hover:shadow-md"
                 >
                   <CardContent className="flex flex-col gap-4 p-6 text-left sm:flex-row sm:items-center sm:justify-between">
                     <div>
-                      <div className="flex items-center gap-3">
+                      <div className="flex flex-wrap items-center gap-3">
                         <Badge variant="secondary" className="rounded-full px-3 py-1 text-xs font-semibold">
                           {listing.stage}
                         </Badge>
                         <span className="text-sm text-muted-foreground">{listing.launch}</span>
+                        <CountdownBadge segments={segments} phase={phase} />
                       </div>
                       <h3 className="mt-3 text-xl font-semibold tracking-tight">{listing.name}</h3>
                       <p className="mt-2 text-sm text-muted-foreground sm:max-w-md">{listing.description}</p>
                     </div>
                     <div className="flex flex-col items-start gap-3 sm:items-end">
                       <span className="text-sm font-medium text-muted-foreground">{listing.interest}</span>
-                      <Button variant="secondary" className="rounded-full px-6">
-                        Join waitlist
-                      </Button>
+                      {phase === "live" ? (
+                        <Button variant="secondary" className="rounded-full px-6">
+                          View live market
+                        </Button>
+                      ) : (
+                        <Button variant="secondary" className="rounded-full px-6">
+                          Join waitlist
+                        </Button>
+                      )}
                     </div>
                   </CardContent>
                 </Card>
@@ -226,9 +270,12 @@ export default function CoinsPage() {
                     allocation window again.
                   </p>
                 </div>
-                <div className="mt-8 space-y-4">
-                  {LISTING_HIGHLIGHTS.map((highlight) => (
-                    <div key={highlight.title} className="rounded-xl border border-muted/40 bg-background/60 p-4">
+                <div className="mt-8 space-y-5">
+                  {highlightSet.map((highlight) => (
+                    <div
+                      key={highlight.title}
+                      className="rounded-xl border border-muted/40 bg-background/60 p-4 transition-colors duration-[var(--t-med)] ease-[var(--ease)]"
+                    >
                       <div className="flex items-center justify-between">
                         <div>
                           <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
@@ -243,6 +290,39 @@ export default function CoinsPage() {
                       </div>
                     </div>
                   ))}
+                  <div className="rounded-xl border border-muted/40 bg-background/60 p-4 transition-colors duration-[var(--t-med)] ease-[var(--ease)]">
+                    <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Mining Economics</h3>
+                    <div className="mt-4 space-y-4">
+                      {ECONOMICS_RULES.map((rule) => (
+                        <div
+                          key={rule.label}
+                          className="flex items-start justify-between gap-4 rounded-lg bg-background/70 p-3 shadow-sm shadow-black/5"
+                        >
+                          <div>
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground">{rule.label}</p>
+                            <p className="mt-1 text-sm text-muted-foreground/80">
+                              {snapshotKey === "live" ? rule.live : rule.scheduled}
+                            </p>
+                          </div>
+                          <span className="text-sm font-semibold text-primary">{rule.value}</span>
+                        </div>
+                      ))}
+                    </div>
+                    <div className="mt-5 space-y-3">
+                      {progressSnapshot.map((progress) => (
+                        <div key={progress.label}>
+                          <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.25em] text-muted-foreground">
+                            <span>{progress.label}</span>
+                            <span>{progress.value}%</span>
+                          </div>
+                          <Progress value={progress.value} className="mt-2 h-2 overflow-hidden">
+                            <span className="sr-only">{progress.label}</span>
+                          </Progress>
+                          <p className="mt-1 text-xs text-muted-foreground">{progress.helper}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
                 </div>
               </CardContent>
             </Card>

--- a/app/globals.css
+++ b/app/globals.css
@@ -30,6 +30,15 @@
   --chart-4: oklch(0.65 0.15 120); /* Crypto green */
   --chart-5: oklch(0.5 0.2 15); /* Crypto orange */
   --radius: 0.75rem;
+  --ease: cubic-bezier(.2, .8, .2, 1);
+  --t-fast: 180ms;
+  --t-med: 240ms;
+  --z-header: 100;
+  --z-dropdown: 900;
+  --z-modal: 1000;
+  --z-toast: 1100;
+  --z-loader: 1200;
+  --elev: 0 12px 28px rgba(15, 23, 42, 0.12);
   --sidebar: oklch(0.98 0.005 240);
   --sidebar-foreground: oklch(0.15 0.02 240);
   --sidebar-primary: oklch(0.55 0.18 45);
@@ -129,6 +138,63 @@
 
 body {
   font-feature-settings: "rlig" 1, "calt" 1;
+}
+
+:where(button, .button, .icon-btn, a, [role="button"]) {
+  transition: transform var(--t-fast) var(--ease), box-shadow var(--t-fast) var(--ease), color var(--t-fast) var(--ease), background-color var(--t-fast) var(--ease), opacity var(--t-fast) var(--ease);
+}
+
+:where(button, .button, .icon-btn, a, [role="button"]):hover {
+  transform: translateY(-2px);
+  box-shadow: var(--elev);
+}
+
+:where(button, .button, .icon-btn, a, [role="button"]):active {
+  transform: translateY(-1px) scale(0.98);
+}
+
+.popover {
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity var(--t-med) var(--ease), transform var(--t-med) var(--ease);
+}
+
+.popover.open {
+  opacity: 1;
+  transform: none;
+}
+
+.u-transition {
+  transition: all var(--t-med) var(--ease);
+}
+
+.u-fade-in {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
+.u-fade-in.show {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+#top-loader {
+  position: fixed;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: linear-gradient(90deg, #ff5a1f, #ffb703);
+  transform-origin: 0 50%;
+  transform: scaleX(0);
+  z-index: var(--z-loader);
+  transition: transform 160ms var(--ease);
+  pointer-events: none;
 }
 
 /* Enhanced scrollbar with crypto theme colors */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type React from "react"
 import type { Metadata } from "next"
 import { ThemeProvider } from "@/components/theme-provider"
+import { TopLoader } from "@/components/top-loader"
 import { cn } from "@/lib/utils"
 
 import "./globals.css"
@@ -20,7 +21,9 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={cn("min-h-screen bg-background font-sans antialiased text-foreground")}>
+        <div id="top-loader" aria-hidden="true" />
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
+          <TopLoader />
           {children}
         </ThemeProvider>
       </body>

--- a/components/launch/countdown-display.tsx
+++ b/components/launch/countdown-display.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import { useEffect, useId, useMemo, useState } from "react"
+
+import { type CountdownSegment, type LaunchPhase } from "@/hooks/use-launch-countdown"
+import { cn } from "@/lib/utils"
+
+interface CountdownDisplayProps {
+  segments: CountdownSegment[]
+  phase: LaunchPhase
+}
+
+function useLocalizedLabel(unit: CountdownSegment["unit"]) {
+  const locale = useMemo(() => {
+    if (typeof navigator !== "undefined" && navigator.language) {
+      return navigator.language
+    }
+    if (typeof Intl !== "undefined") {
+      return Intl.DateTimeFormat().resolvedOptions().locale
+    }
+    return "en-US"
+  }, [])
+
+  return useMemo(() => {
+    const singular = unit === "days" ? "day" : unit === "hours" ? "hour" : unit === "minutes" ? "minute" : "second"
+
+      if (typeof Intl.DisplayNames === "function") {
+        try {
+          const formatter = new Intl.DisplayNames([locale], { type: "unit" })
+          return formatter.of(singular) ?? singular
+        } catch (error) {
+          return singular
+        }
+      }
+
+    return singular
+  }, [locale, unit])
+}
+
+interface CountdownTileProps {
+  segment: CountdownSegment
+}
+
+function CountdownTile({ segment }: CountdownTileProps) {
+  const [isFlipping, setIsFlipping] = useState(false)
+  const label = useLocalizedLabel(segment.unit)
+  const labelId = useId()
+
+  useEffect(() => {
+    setIsFlipping(true)
+    const timeout = window.setTimeout(() => {
+      setIsFlipping(false)
+    }, 220)
+    return () => window.clearTimeout(timeout)
+  }, [segment.value])
+
+  return (
+    <div
+      aria-labelledby={labelId}
+      className={cn(
+        "flex w-full flex-col items-center gap-1 rounded-2xl border border-border/60 bg-background/90 p-4 text-center shadow-[0_14px_35px_rgba(15,23,42,0.08)] transition-shadow duration-[var(--t-med)] ease-[var(--ease)]", // tile styling
+        "backdrop-blur-sm",
+      )}
+    >
+      <span
+        className={cn(
+          "relative inline-flex h-16 w-full items-center justify-center overflow-hidden rounded-xl bg-gradient-to-b from-background via-background to-muted text-5xl font-semibold tabular-nums text-foreground transition-[transform,opacity] duration-[var(--t-med)] ease-[var(--ease)] sm:text-6xl",
+          isFlipping ? "opacity-75 motion-safe:-translate-y-1" : "opacity-100 motion-safe:translate-y-0",
+        )}
+        aria-live="off"
+      >
+        {segment.value.toString().padStart(2, "0")}
+      </span>
+      <span
+        id={labelId}
+        className="text-[0.7rem] font-semibold uppercase tracking-[0.4em] text-muted-foreground"
+      >
+        {label.toUpperCase()}
+      </span>
+    </div>
+  )
+}
+
+export function CountdownDisplay({ segments, phase }: CountdownDisplayProps) {
+  return (
+    <div
+      className={cn(
+        "grid w-full max-w-3xl grid-cols-2 gap-3 sm:grid-cols-4",
+        phase === "live" ? "opacity-60" : "opacity-100",
+      )}
+      aria-live="polite"
+    >
+      {segments.map((segment) => (
+        <CountdownTile key={segment.unit} segment={segment} />
+      ))}
+    </div>
+  )
+}
+
+interface CountdownBadgeProps {
+  segments: CountdownSegment[]
+  phase: LaunchPhase
+}
+
+export function CountdownBadge({ segments, phase }: CountdownBadgeProps) {
+  if (phase === "live") {
+    return (
+      <span className="inline-flex items-center gap-2 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-500 shadow-sm">
+        LIVE
+      </span>
+    )
+  }
+
+  const formatted = segments
+    .map((segment) => `${segment.value.toString().padStart(2, "0")} ${segment.unit.slice(0, 1).toUpperCase()}`)
+    .join(" · ")
+
+  return (
+    <span className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-primary shadow-sm">
+      {formatted}
+    </span>
+  )
+}

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -166,7 +166,7 @@ export function Sidebar({ user }: SidebarProps) {
         <SidebarContent />
       </div>
 
-      <div className="fixed top-8 right-6 z-50 hidden md:flex">
+      <div className="fixed top-8 right-6 z-[var(--z-header)] hidden md:flex">
         <div className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/80 px-4 py-2 shadow-lg shadow-black/5 backdrop-blur">
           <NotificationBell />
           <span className="h-5 w-px bg-border/60" aria-hidden />

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,45 +1,177 @@
 "use client"
 
-import { useEffect, useState } from "react"
-import { MoonStar, Sun } from "lucide-react"
+import { useEffect, useId, useMemo, useState } from "react"
+import { createPortal } from "react-dom"
+
+import { MonitorCog, MoonStar, RefreshCw, Sparkles, Sun } from "lucide-react"
+import { useRouter } from "next/navigation"
 import { useTheme } from "next-themes"
 
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
+const themeOptions = [
+  {
+    id: "system",
+    label: "System",
+    description: "Auto-switch with OS",
+    icon: MonitorCog,
+    value: "system",
+  },
+  {
+    id: "light",
+    label: "Light",
+    description: "Bright trading floor",
+    icon: Sun,
+    value: "light",
+  },
+  {
+    id: "dark",
+    label: "Dark",
+    description: "Midnight miner",
+    icon: MoonStar,
+    value: "dark",
+  },
+] as const
+
 export function ThemeToggle() {
-  const { resolvedTheme, setTheme } = useTheme()
+  const { resolvedTheme, setTheme, theme } = useTheme()
+  const [open, setOpen] = useState(false)
   const [mounted, setMounted] = useState(false)
+  const router = useRouter()
+  const menuId = useId()
 
   useEffect(() => {
     setMounted(true)
   }, [])
 
-  if (!mounted) {
-    return (
-      <Button variant="ghost" size="icon" className="relative" aria-label="Toggle theme" disabled>
-        <Sun className="h-5 w-5 opacity-0" />
-      </Button>
-    )
-  }
+  const activeTheme = useMemo(() => (resolvedTheme ?? theme ?? "system"), [resolvedTheme, theme])
 
-  const isDark = resolvedTheme === "dark"
+  useEffect(() => {
+    if (!open) return
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false)
+      }
+    }
+
+    document.addEventListener("keydown", handleKey)
+    return () => document.removeEventListener("keydown", handleKey)
+  }, [open])
+
+  const overlay = mounted && open
+    ? createPortal(
+        <div
+          className="fixed inset-0 z-[calc(var(--z-dropdown,900)-1)] bg-background/20 backdrop-blur-[1.5px]"
+          onClick={() => setOpen(false)}
+          aria-hidden="true"
+        />,
+        document.body,
+      )
+    : null
 
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
-      className="relative overflow-hidden"
-      onClick={() => setTheme(isDark ? "light" : "dark")}
-    >
-      <Sun className={cn("h-5 w-5 transition-all", isDark ? "-rotate-90 scale-0" : "rotate-0 scale-100")} />
-      <MoonStar
-        className={cn(
-          "absolute h-5 w-5 transition-all",
-          isDark ? "rotate-0 scale-100" : "rotate-90 scale-0",
-        )}
-      />
-    </Button>
+    <>
+      {overlay}
+      <Popover open={open} onOpenChange={setOpen} modal>
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Open quick actions"
+            aria-expanded={open}
+            aria-controls={open ? menuId : undefined}
+            className={cn(
+              "relative flex h-11 w-11 items-center justify-center rounded-full border border-border/70 bg-background/70 shadow-sm transition-all duration-[var(--t-fast,180ms)] ease-[var(--ease)]",
+              "hover:-translate-y-[2px] hover:shadow-[0_12px_24px_rgba(15,23,42,0.12)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+            )}
+          >
+            <Sun
+              className={cn(
+                "h-5 w-5 transition-transform duration-[var(--t-med,240ms)] ease-[var(--ease)]",
+                activeTheme === "dark" ? "-rotate-90 scale-0 opacity-0" : "rotate-0 scale-100 opacity-100",
+              )}
+            />
+            <MoonStar
+              className={cn(
+                "absolute h-5 w-5 transition-transform duration-[var(--t-med,240ms)] ease-[var(--ease)]",
+                activeTheme === "dark" ? "rotate-0 scale-100 opacity-100" : "rotate-90 scale-0 opacity-0",
+              )}
+            />
+            <span className="sr-only">Toggle theme</span>
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          id={menuId}
+          align="end"
+          sideOffset={12}
+          className={cn(
+            "popover w-[min(20rem,90vw)] rounded-2xl border border-border/70 bg-background/95 p-4 shadow-xl shadow-black/10 backdrop-blur-lg",
+            open && "open",
+          )}
+          style={{ position: "fixed" }}
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-semibold text-foreground">Quick actions</p>
+              <p className="text-xs text-muted-foreground">Theme, refresh &amp; live status</p>
+            </div>
+            <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-primary">
+              UI
+            </span>
+          </div>
+
+          <div className="mt-4 grid grid-cols-3 gap-2" role="group" aria-label="Theme selection">
+            {themeOptions.map((option) => {
+              const Icon = option.icon
+              const isActive = activeTheme === option.value
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  onClick={() => setTheme(option.value)}
+                  className={cn(
+                    "group flex h-24 flex-col items-center justify-center gap-2 rounded-xl border border-border/70 bg-background/70 text-center transition-all duration-[var(--t-med,240ms)] ease-[var(--ease)]",
+                    "hover:-translate-y-1 hover:border-primary/50 hover:shadow-[0_12px_28px_rgba(15,23,42,0.12)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+                    isActive ? "border-primary/60 bg-primary/10 text-primary" : "text-muted-foreground",
+                  )}
+                >
+                  <Icon className="h-5 w-5" aria-hidden="true" />
+                  <span className="text-xs font-semibold uppercase tracking-[0.3em]">{option.label}</span>
+                  <span className="text-[0.65rem] text-muted-foreground">{option.description}</span>
+                </button>
+              )
+            })}
+          </div>
+
+          <div className="mt-5 space-y-3" role="group" aria-label="Utilities">
+            <button
+              type="button"
+              onClick={() => {
+                router.refresh()
+                setOpen(false)
+              }}
+              className="flex w-full items-center justify-between rounded-xl border border-border/60 bg-background/70 px-4 py-3 text-left text-sm transition-all duration-[var(--t-med,240ms)] ease-[var(--ease)] hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-[0_10px_24px_rgba(15,23,42,0.12)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+            >
+              <div>
+                <p className="font-semibold text-foreground">Refresh data</p>
+                <p className="text-xs text-muted-foreground">Revalidate dashboards &amp; balances</p>
+              </div>
+              <RefreshCw className="h-4 w-4 text-primary" aria-hidden="true" />
+            </button>
+
+            <div className="flex items-center justify-between rounded-xl border border-border/60 bg-background/70 px-4 py-3">
+              <div>
+                <p className="text-sm font-semibold text-foreground">Launch status</p>
+                <p className="text-xs text-muted-foreground">Auto-updates with countdown</p>
+              </div>
+              <Sparkles className="h-4 w-4 text-primary" aria-hidden="true" />
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </>
   )
 }

--- a/components/top-loader.tsx
+++ b/components/top-loader.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+import Router from "next/router"
+
+const MIN_PROGRESS = 0.08
+const INCREMENT_INTERVAL = 300
+
+export function TopLoader() {
+  const activeRequests = useRef(0)
+  const progress = useRef(0)
+  const intervalRef = useRef<number | null>(null)
+  const barRef = useRef<HTMLDivElement | null>(null)
+  const originalFetch = useRef<typeof window.fetch | null>(null)
+
+  useEffect(() => {
+    barRef.current = document.getElementById("top-loader") as HTMLDivElement | null
+  }, [])
+
+  useEffect(() => {
+    const set = (value: number) => {
+      progress.current = Math.max(0, Math.min(1, value))
+      barRef.current?.style.setProperty("transform", `scaleX(${progress.current})`)
+    }
+
+    const start = () => {
+      if (activeRequests.current === 0) {
+        set(MIN_PROGRESS)
+        intervalRef.current = window.setInterval(() => {
+          const next = progress.current + (1 - progress.current) * 0.1
+          set(next)
+        }, INCREMENT_INTERVAL) as unknown as number
+      }
+      activeRequests.current += 1
+    }
+
+    const done = () => {
+      if (activeRequests.current === 0) return
+      activeRequests.current -= 1
+      if (activeRequests.current === 0) {
+        if (intervalRef.current) {
+          window.clearInterval(intervalRef.current)
+          intervalRef.current = null
+        }
+        set(1)
+        window.setTimeout(() => {
+          set(0)
+        }, 220)
+      }
+    }
+
+    const handleStart = () => start()
+    const handleDone = () => done()
+
+    Router.events.on("routeChangeStart", handleStart)
+    Router.events.on("routeChangeComplete", handleDone)
+    Router.events.on("routeChangeError", handleDone)
+
+    if (typeof window !== "undefined" && !originalFetch.current) {
+      originalFetch.current = window.fetch
+      window.fetch = async (...args) => {
+        start()
+        try {
+          return await originalFetch.current!(...args)
+        } finally {
+          done()
+        }
+      }
+    }
+
+    return () => {
+      Router.events.off("routeChangeStart", handleStart)
+      Router.events.off("routeChangeComplete", handleDone)
+      Router.events.off("routeChangeError", handleDone)
+
+      if (intervalRef.current) {
+        window.clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+
+      if (originalFetch.current) {
+        window.fetch = originalFetch.current
+        originalFetch.current = null
+      }
+    }
+  }, [])
+
+  return null
+}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -42,7 +42,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[var(--z-dropdown,900)] max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
           className,
         )}
         {...props}

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -30,7 +30,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[var(--z-dropdown,900)] w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
           className,
         )}
         {...props}

--- a/hooks/use-launch-countdown.ts
+++ b/hooks/use-launch-countdown.ts
@@ -1,0 +1,232 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+export type LaunchPhase = "scheduled" | "launching" | "live"
+
+export interface CountdownSegment {
+  unit: "days" | "hours" | "minutes" | "seconds"
+  value: number
+}
+
+interface CountdownState {
+  segments: CountdownSegment[]
+  remainingMs: number
+}
+
+const SECOND_MS = 1000
+const MINUTE_MS = 60 * SECOND_MS
+const HOUR_MS = 60 * MINUTE_MS
+const DAY_MS = 24 * HOUR_MS
+const RESYNC_INTERVAL_MS = 60 * SECOND_MS
+const MAX_CLOCK_DRIFT_MS = 2000
+const LAUNCH_EVENT = "LAUNCH_STARTED"
+
+function calculateSegments(remainingMs: number): CountdownState {
+  const clamped = Math.max(remainingMs, 0)
+  const days = Math.floor(clamped / DAY_MS)
+  const hours = Math.floor((clamped % DAY_MS) / HOUR_MS)
+  const minutes = Math.floor((clamped % HOUR_MS) / MINUTE_MS)
+  const seconds = Math.floor((clamped % MINUTE_MS) / SECOND_MS)
+
+  return {
+    segments: [
+      { unit: "days", value: days },
+      { unit: "hours", value: hours },
+      { unit: "minutes", value: minutes },
+      { unit: "seconds", value: seconds },
+    ],
+    remainingMs: clamped,
+  }
+}
+
+interface LaunchCountdown {
+  phase: LaunchPhase
+  countdown: CountdownState | null
+  launchAt: Date | null
+  isReady: boolean
+  refresh: () => void
+}
+
+export function useLaunchCountdown(): LaunchCountdown {
+  const [phase, setPhase] = useState<LaunchPhase>("scheduled")
+  const [countdown, setCountdown] = useState<CountdownState | null>(null)
+  const [launchAt, setLaunchAt] = useState<Date | null>(null)
+  const [isReady, setIsReady] = useState(false)
+
+  const offsetRef = useRef(0)
+  const intervalRef = useRef<number | null>(null)
+  const resyncTimerRef = useRef<number | null>(null)
+  const launchingTimeoutRef = useRef<number | null>(null)
+  const hasDispatchedRef = useRef(false)
+  const launchAtRef = useRef<Date | null>(null)
+
+  const computeRemaining = useCallback(() => {
+    const launchDate = launchAtRef.current
+    if (!launchDate) return
+
+    const now = Date.now()
+    const currentServerTime = now - offsetRef.current
+    const remaining = launchDate.getTime() - currentServerTime
+
+    if (remaining <= 0) {
+      setCountdown(calculateSegments(0))
+      if (phase !== "live" && phase !== "launching") {
+        setPhase("launching")
+        if (launchingTimeoutRef.current) {
+          window.clearTimeout(launchingTimeoutRef.current)
+        }
+        launchingTimeoutRef.current = window.setTimeout(() => {
+          if (!hasDispatchedRef.current) {
+            window.dispatchEvent(new CustomEvent(LAUNCH_EVENT))
+            hasDispatchedRef.current = true
+          }
+          setPhase("live")
+        }, 500)
+      } else if (phase === "launching" && !hasDispatchedRef.current) {
+        window.dispatchEvent(new CustomEvent(LAUNCH_EVENT))
+        hasDispatchedRef.current = true
+        setPhase("live")
+      }
+      return
+    }
+
+    hasDispatchedRef.current = false
+    if (phase !== "scheduled") {
+      setPhase("scheduled")
+    }
+
+    setCountdown(calculateSegments(remaining))
+  }, [phase])
+
+  const scheduleTick = useCallback(() => {
+    if (intervalRef.current) {
+      window.clearInterval(intervalRef.current)
+    }
+
+    computeRemaining()
+    intervalRef.current = window.setInterval(computeRemaining, SECOND_MS) as unknown as number
+  }, [computeRemaining])
+
+  const clearTimers = useCallback(() => {
+    if (intervalRef.current) {
+      window.clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+    if (resyncTimerRef.current) {
+      window.clearInterval(resyncTimerRef.current)
+      resyncTimerRef.current = null
+    }
+    if (launchingTimeoutRef.current) {
+      window.clearTimeout(launchingTimeoutRef.current)
+      launchingTimeoutRef.current = null
+    }
+  }, [])
+
+  const hydrateFromPayload = useCallback((payload: { launch_at: string; server_now: string }) => {
+    const launchDate = new Date(payload.launch_at)
+    const serverNow = new Date(payload.server_now)
+
+    if (Number.isNaN(launchDate.getTime()) || Number.isNaN(serverNow.getTime())) {
+      return
+    }
+
+    launchAtRef.current = launchDate
+    setLaunchAt(launchDate)
+    offsetRef.current = Date.now() - serverNow.getTime()
+    setCountdown(calculateSegments(launchDate.getTime() - serverNow.getTime()))
+    setPhase(launchDate.getTime() <= serverNow.getTime() ? "live" : "scheduled")
+    setIsReady(true)
+    scheduleTick()
+  }, [scheduleTick])
+
+  const fetchSchedule = useCallback(async () => {
+    try {
+      const response = await fetch("/api/launch", { cache: "no-store" })
+      if (!response.ok) return
+      const data = (await response.json()) as { launch_at: string; server_now: string }
+      hydrateFromPayload(data)
+    } catch (error) {
+      console.error("Failed to fetch launch schedule", error)
+    }
+  }, [hydrateFromPayload])
+
+  useEffect(() => {
+    fetchSchedule()
+
+    return () => {
+      clearTimers()
+    }
+  }, [fetchSchedule, clearTimers])
+
+  useEffect(() => {
+    if (!launchAt) return
+
+    if (resyncTimerRef.current) {
+      window.clearInterval(resyncTimerRef.current)
+    }
+
+    resyncTimerRef.current = window.setInterval(async () => {
+      try {
+        const response = await fetch("/api/launch", { cache: "no-store" })
+        if (!response.ok) return
+        const data = (await response.json()) as { launch_at: string; server_now: string }
+        const newLaunchAt = new Date(data.launch_at)
+        const newServerNow = new Date(data.server_now)
+        if (Number.isNaN(newLaunchAt.getTime()) || Number.isNaN(newServerNow.getTime())) {
+          return
+        }
+
+        const newOffset = Date.now() - newServerNow.getTime()
+        const shouldResync = Math.abs(newOffset - offsetRef.current) > MAX_CLOCK_DRIFT_MS
+        const launchChanged = launchAtRef.current?.getTime() !== newLaunchAt.getTime()
+
+        if (shouldResync || launchChanged) {
+          offsetRef.current = newOffset
+          launchAtRef.current = newLaunchAt
+          setLaunchAt(newLaunchAt)
+          computeRemaining()
+        }
+      } catch (error) {
+        console.error("Failed to resync launch schedule", error)
+      }
+    }, RESYNC_INTERVAL_MS) as unknown as number
+
+    return () => {
+      if (resyncTimerRef.current) {
+        window.clearInterval(resyncTimerRef.current)
+        resyncTimerRef.current = null
+      }
+    }
+  }, [launchAt, computeRemaining])
+
+  useEffect(() => {
+    return () => {
+      clearTimers()
+    }
+  }, [clearTimers])
+
+  const countdownValue = useMemo(() => {
+    if (!countdown) return null
+    return countdown
+  }, [countdown])
+
+  return {
+    phase,
+    countdown: countdownValue,
+    launchAt,
+    isReady,
+    refresh: fetchSchedule,
+  }
+}
+
+export function formatCompactCountdown(segments: CountdownSegment[]): string {
+  return segments
+    .map(({ unit, value }) => {
+      const symbol = unit === "days" ? "d" : unit === "hours" ? "h" : unit === "minutes" ? "m" : "s"
+      return `${value.toString().padStart(2, "0")}${symbol}`
+    })
+    .join(" · ")
+}
+
+export { LAUNCH_EVENT }

--- a/lib/config/launch.ts
+++ b/lib/config/launch.ts
@@ -1,0 +1,26 @@
+export interface LaunchConfig {
+  /** ISO8601 timestamp describing when the launch goes live. */
+  launchAt: string
+}
+
+const DEFAULT_OFFSET_DAYS = 87
+const ENV_LAUNCH_AT = process.env.LAUNCH_AT
+
+const launchAt = (() => {
+  if (ENV_LAUNCH_AT) {
+    const parsed = new Date(ENV_LAUNCH_AT)
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString()
+    }
+    console.error("Invalid LAUNCH_AT environment variable, falling back to offset schedule")
+  }
+
+  const now = new Date()
+  const launchDate = new Date(now.getTime() + DEFAULT_OFFSET_DAYS * 24 * 60 * 60 * 1000)
+  launchDate.setMilliseconds(0)
+  return launchDate.toISOString()
+})()
+
+export const launchConfig: LaunchConfig = {
+  launchAt,
+}

--- a/lib/services/launch.ts
+++ b/lib/services/launch.ts
@@ -1,0 +1,11 @@
+import { launchConfig } from "@/lib/config/launch"
+
+export interface LaunchSchedule {
+  launchAt: Date
+}
+
+export function getLaunchSchedule(): LaunchSchedule {
+  return {
+    launchAt: new Date(launchConfig.launchAt),
+  }
+}


### PR DESCRIPTION
## Summary
- add a launch schedule API and countdown hook that resynchronizes from server time
- refresh the coins page UI to share the live countdown across cards and mining economics states
- rebuild the header quick actions with an accessible popover, motion tokens, and a top loading indicator

## Testing
- npm run lint *(fails: interactive Next.js ESLint setup prompt in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e228c1799083278de94e232331b8a6