### PR TITLE
Fix login proxy and polish loader UX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ MONGODB_URI=mongodb+srv://sohaibiqbal3429:Muhammad1@cluster0.ki2kppi.mongodb.net
 NEXTAUTH_SECRET=c73d8d2063c5cdde74a4e3554d2129435cf96df3d97fe3978004fa20a568be9e
 NEXTAUTH_URL=http://localhost:3000
 
+# External authentication service (optional proxy configuration)
+# AUTH_SERVICE_LOGIN_URL=https://api.example.com/auth/login
+# AUTH_SERVICE_URL=https://api.example.com
+
 
 # Wallet
 DEPOSIT_WALLET_ADDRESS_1=0x9e2d640110ee86ea961a3864f842db21baada57d

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,15 +1,133 @@
 import { type NextRequest, NextResponse } from "next/server"
+import { ZodError } from "zod"
+
 import dbConnect from "@/lib/mongodb"
 import User from "@/models/User"
-import { loginSchema } from "@/lib/validations/auth"
+import { loginSchema, type LoginInput } from "@/lib/validations/auth"
 import { comparePassword, signToken } from "@/lib/auth"
+
+const MAX_TOKEN_AGE = 7 * 24 * 60 * 60 // 7 days
+
+function resolveExternalLoginUrl() {
+  const rawUrl =
+    process.env.AUTH_SERVICE_LOGIN_URL ??
+    process.env.AUTH_SERVICE_URL ??
+    process.env.BACKEND_API_URL ??
+    process.env.API_BASE_URL
+
+  if (!rawUrl) {
+    return null
+  }
+
+  try {
+    const url = new URL(rawUrl)
+    const pathname = url.pathname.replace(/\/$/, "")
+    if (!/auth\/login$/i.test(pathname)) {
+      url.pathname = `${pathname || ""}/auth/login`
+    }
+    return url
+  } catch (error) {
+    console.error("Invalid AUTH service URL", error)
+    return null
+  }
+}
+
+async function proxyLoginRequest(payload: LoginInput) {
+  const targetUrl = resolveExternalLoginUrl()
+
+  if (!targetUrl) {
+    return null
+  }
+
+  let backendResponse: Response
+
+  try {
+    backendResponse = await fetch(targetUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(payload),
+      credentials: "include",
+    })
+  } catch (error) {
+    console.error("Failed to contact authentication service", error)
+    throw new Error("Server not reachable. Please try later.")
+  }
+
+  const rawBody = await backendResponse.text()
+  let parsedBody: any = null
+
+  if (rawBody) {
+    try {
+      parsedBody = JSON.parse(rawBody)
+    } catch {
+      parsedBody = rawBody
+    }
+  }
+
+  if (!backendResponse.ok || (parsedBody && typeof parsedBody === "object" && parsedBody.success === false)) {
+    const message =
+      (parsedBody && typeof parsedBody === "object" && typeof parsedBody.error === "string" && parsedBody.error) ||
+      (parsedBody && typeof parsedBody === "object" && typeof parsedBody.message === "string" && parsedBody.message) ||
+      (typeof parsedBody === "string" && parsedBody) ||
+      "Login failed. Please try again."
+
+    const status = backendResponse.status || 502
+    return NextResponse.json({ error: message }, { status })
+  }
+
+  const token =
+    (parsedBody && typeof parsedBody === "object" && typeof parsedBody.token === "string" && parsedBody.token) ||
+    (parsedBody &&
+      typeof parsedBody === "object" &&
+      parsedBody.data &&
+      typeof parsedBody.data === "object" &&
+      typeof (parsedBody.data as Record<string, unknown>).token === "string" &&
+      ((parsedBody.data as Record<string, unknown>).token as string)) ||
+    null
+
+  const user =
+    (parsedBody && typeof parsedBody === "object" && parsedBody.user && typeof parsedBody.user === "object" && parsedBody.user) ||
+    (parsedBody &&
+      typeof parsedBody === "object" &&
+      parsedBody.data &&
+      typeof parsedBody.data === "object" &&
+      (parsedBody.data as Record<string, unknown>).user &&
+      typeof (parsedBody.data as Record<string, unknown>).user === "object" &&
+      (parsedBody.data as Record<string, unknown>).user) ||
+    null
+
+  const response = NextResponse.json({
+    success: true,
+    user,
+  })
+
+  if (token) {
+    response.cookies.set("auth-token", token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: MAX_TOKEN_AGE,
+      path: "/",
+    })
+  }
+
+  return response
+}
 
 export async function POST(request: NextRequest) {
   try {
-    await dbConnect()
-
     const body = await request.json()
     const validatedData = loginSchema.parse(body)
+
+    const proxiedResponse = await proxyLoginRequest(validatedData)
+    if (proxiedResponse) {
+      return proxiedResponse
+    }
+
+    await dbConnect()
 
     const { identifier, identifierType, password } = validatedData
 
@@ -18,19 +136,16 @@ export async function POST(request: NextRequest) {
         ? { email: identifier.toLowerCase() }
         : { phone: identifier }
 
-    // Find user
     const user = await User.findOne(query)
     if (!user) {
-      return NextResponse.json({ error: "Invalid credentials" }, { status: 401 })
+      return NextResponse.json({ error: "Invalid email or password." }, { status: 401 })
     }
 
-    // Verify password
     const isValidPassword = await comparePassword(password, user.passwordHash)
     if (!isValidPassword) {
-      return NextResponse.json({ error: "Invalid credentials" }, { status: 401 })
+      return NextResponse.json({ error: "Invalid email or password." }, { status: 401 })
     }
 
-    // Generate JWT token
     const token = signToken({
       userId: user._id.toString(),
       email: user.email,
@@ -48,20 +163,24 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    // Set HTTP-only cookie
     response.cookies.set("auth-token", token, {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
-      maxAge: 7 * 24 * 60 * 60, // 7 days
+      maxAge: MAX_TOKEN_AGE,
+      path: "/",
     })
 
     return response
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error("Login error:", error)
 
-    if (error.name === "ZodError") {
+    if (error instanceof ZodError) {
       return NextResponse.json({ error: "Validation failed", details: error.errors }, { status: 400 })
+    }
+
+    if (error instanceof Error && error.message) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
     }
 
     return NextResponse.json({ error: "Internal server error" }, { status: 500 })

--- a/app/globals.css
+++ b/app/globals.css
@@ -216,21 +216,6 @@ body {
   }
 }
 
-#top-loader {
-  position: fixed;
-  inset: 0 0 auto 0;
-  height: 3px;
-  background: linear-gradient(90deg, #ff5a1f, #ffb703);
-  transform-origin: 0 50%;
-  transform: scaleX(0);
-  z-index: var(--z-loader);
-  opacity: 0;
-  visibility: hidden;
-  transition: transform var(--t-med) var(--ease), opacity var(--t-fast) var(--ease);
-  will-change: transform, opacity;
-  pointer-events: none;
-}
-
 /* Enhanced scrollbar with crypto theme colors */
 ::-webkit-scrollbar { width: 8px; }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,8 @@
 import type React from "react"
+import { Suspense } from "react"
 import type { Metadata } from "next"
 import { ThemeProvider } from "@/components/theme-provider"
-import { TopLoader } from "@/components/top-loader"
+import { TopLoaderProvider } from "@/components/top-loader"
 import { cn } from "@/lib/utils"
 
 import "./globals.css"
@@ -10,7 +11,7 @@ export const metadata: Metadata = {
   title: "CryptoMine - Next-Generation Mining Platform",
   description:
     "Join our innovative mining ecosystem with referral rewards, team building, and sustainable earning opportunities.",
-    generator: 'v0.app'
+  generator: "v0.app",
 }
 
 export default function RootLayout({
@@ -21,11 +22,13 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={cn("min-h-screen bg-background font-sans antialiased text-foreground")}>
-        <div id="top-loader" aria-hidden="true" />
-        <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
-          <TopLoader />
-          {children}
-        </ThemeProvider>
+        <Suspense fallback={null}>
+          <TopLoaderProvider>
+            <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
+              {children}
+            </ThemeProvider>
+          </TopLoaderProvider>
+        </Suspense>
       </body>
     </html>
   )

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive motion-safe:transition-[background,box-shadow,transform,color] motion-safe:duration-200 motion-safe:ease-out motion-safe:active:scale-[0.97] motion-safe:focus-visible:scale-[0.99]",
   {
     variants: {
       variant: {

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="card"
       className={cn(
-        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm motion-safe:transition-all motion-safe:duration-300 motion-safe:ease-out motion-safe:hover:-translate-y-1 motion-safe:hover:shadow-lg motion-safe:focus-within:-translate-y-1 motion-safe:focus-within:shadow-lg',
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- add optional external proxy support to `/api/auth/login` with detailed error responses and fall back to the existing database flow
- modernize the client login form with loader integration, clearer feedback, and motion-safe UI transitions
- replace the legacy top loader with a context-based provider, wrap the app layout in suspense, and clean up supporting styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2376002ac8327910606b2eb958dee