### PR TITLE
Implement qualifying deposit activation

### DIFF
--- a/app/api/wallet/deposit/route.ts
+++ b/app/api/wallet/deposit/route.ts
@@ -58,6 +58,7 @@ export async function POST(request: NextRequest) {
         ...(result.receiptMeta ? { receiptUrl: result.receiptMeta.url } : {}),
       },
       message: result.message,
+      activated: Boolean(result.activated),
     })
   } catch (error: any) {
     if (error instanceof DepositSubmissionError) {


### PR DESCRIPTION
## Summary
- flag approved deposits that reach the qualifying threshold and enhance notifications with activation messaging
- surface activation state when submitting deposits so the wallet API can relay it to clients
- update commission handling to mark users active once their deposit total qualifies and to release rewards on those deposits

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e2c2d416f483278b74b6fc0fd34b7e