### PR TITLE
Update mining yield copy and dashboard team reward label

### DIFF
--- a/app/coins/page.tsx
+++ b/app/coins/page.tsx
@@ -126,7 +126,7 @@ const ECONOMICS_RULES = [
   },
   {
     label: "Daily Mining Yield",
-    value: "2.5%",
+    value: "1.5% to 5%",
     scheduled: "Projected daily return once hashing begins.",
     live: "Compounded every cycle and streamed to balances.",
   },

--- a/components/dashboard/kpi-cards.tsx
+++ b/components/dashboard/kpi-cards.tsx
@@ -55,7 +55,7 @@ export function KPICards({ kpis }: KPICardsProps) {
       bgColor: "bg-orange-50",
     },
     {
-      title: "Team Reward",
+      title: "Daily Team Reward",
       value: formatCurrency(kpis.teamReward),
       icon: Trophy,
       color: "text-indigo-600",


### PR DESCRIPTION
## Summary
- update the daily mining yield copy on the coins page to reflect the new 1.5% to 5% range
- rename the dashboard KPI label to Daily Team Reward so claimed rewards are clearly surfaced

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2c9cdf750832796d29a968015ce0f