### PR TITLE
Fix admin header duplication and receipt previews

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react"
 import type { Metadata } from "next"
 import { ThemeProvider } from "@/components/theme-provider"
 import { TopLoaderProvider } from "@/components/top-loader"
+import { AppHeader } from "@/components/layout/app-header"
 import { cn } from "@/lib/utils"
 
 import "./globals.css"
@@ -25,6 +26,7 @@ export default function RootLayout({
         <Suspense fallback={null}>
           <TopLoaderProvider>
             <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
+              <AppHeader />
               {children}
             </ThemeProvider>
           </TopLoaderProvider>

--- a/components/admin/admin-dashboard.tsx
+++ b/components/admin/admin-dashboard.tsx
@@ -10,8 +10,6 @@ import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Button } from "@/components/ui/button"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { NotificationBell } from "@/components/notifications/notification-bell"
-import { ThemeToggle } from "@/components/theme-toggle"
 import { Clock, DollarSign, Loader2, RefreshCw, Users } from "lucide-react"
 import type {
   AdminStats,
@@ -191,11 +189,6 @@ export function AdminDashboard({
             </div>
 
             <div className="flex flex-wrap items-center gap-4">
-              <div className="flex items-center gap-3">
-                <NotificationBell />
-                <ThemeToggle />
-              </div>
-
               <Button
                 onClick={() => fetchData({ transactionPage: 1, userPage: 1 })}
                 variant="secondary"

--- a/components/admin/transaction-table.tsx
+++ b/components/admin/transaction-table.tsx
@@ -93,6 +93,20 @@ export function TransactionTable({ transactions, pagination, onPageChange, onRef
     return receiptMeta.url.startsWith("/") ? receiptMeta.url : `/${receiptMeta.url}`
   }, [receiptMeta?.url])
 
+  const isImageReceipt = useMemo(() => {
+    if (!receiptMeta) return false
+    if (receiptMeta.mimeType && /image\/(png|jpe?g|webp|gif)/i.test(receiptMeta.mimeType)) {
+      return true
+    }
+
+    if (receiptMeta.url && typeof receiptMeta.url === "string") {
+      const cleanedUrl = receiptMeta.url.split("?")[0] ?? ""
+      return /\.(png|jpe?g|webp|gif)$/i.test(cleanedUrl)
+    }
+
+    return false
+  }, [receiptMeta])
+
   useEffect(() => {
     setImageError(false)
   }, [resolvedReceiptUrl])
@@ -370,15 +384,16 @@ export function TransactionTable({ transactions, pagination, onPageChange, onRef
               {receiptMeta?.url && (
                 <div className="space-y-2">
                   <Label>Receipt Screenshot</Label>
-                  {resolvedReceiptUrl && !imageError ? (
-                    <div className="overflow-hidden rounded-md border bg-muted/60">
-                      <img
-                        src={resolvedReceiptUrl}
-                        alt={`Deposit receipt ${receiptMeta.originalName ?? ""}`}
-                        className="max-h-96 w-full bg-background object-contain"
-                        onError={() => setImageError(true)}
-                      />
-                    </div>
+                  {isImageReceipt && resolvedReceiptUrl && !imageError ? (
+                    <img
+                      src={resolvedReceiptUrl}
+                      alt={receiptMeta.originalName ? `Deposit receipt ${receiptMeta.originalName}` : "Deposit receipt"}
+                      className="max-h-72 w-auto rounded-md border bg-background object-contain"
+                      onError={(event) => {
+                        event.currentTarget.style.display = "none"
+                        setImageError(true)
+                      }}
+                    />
                   ) : (
                     <div className="rounded-md border bg-muted/60 p-4 text-sm text-muted-foreground">
                       Receipt preview unavailable. Use the link below to view the original file.

--- a/components/layout/app-header.tsx
+++ b/components/layout/app-header.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { QuickActions } from "@/components/layout/quick-actions"
+import { NotificationBell } from "@/components/notifications/notification-bell"
+import { ThemeToggle } from "@/components/theme-toggle"
+
+export function AppHeader() {
+  return (
+    <div className="pointer-events-none fixed right-4 top-4 z-[var(--z-header)] flex w-full justify-end px-2 sm:right-6 sm:top-6">
+      <div className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/80 px-2 py-1.5 shadow-lg shadow-black/5 backdrop-blur">
+        <QuickActions />
+        <span className="h-5 w-px bg-border/60" aria-hidden />
+        <NotificationBell />
+        <span className="h-5 w-px bg-border/60" aria-hidden />
+        <ThemeToggle />
+      </div>
+    </div>
+  )
+}

--- a/components/layout/quick-actions.tsx
+++ b/components/layout/quick-actions.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { Bolt, CreditCard, HelpCircle, History, Send, type LucideIcon } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+
+interface QuickAction {
+  href: string
+  label: string
+  description: string
+  icon: LucideIcon
+}
+
+const quickActions: QuickAction[] = [
+  {
+    href: "/wallet/deposit",
+    label: "Submit deposit receipt",
+    description: "Upload proof of your latest transfer",
+    icon: CreditCard,
+  },
+  {
+    href: "/transactions",
+    label: "Review transactions",
+    description: "Check deposit and withdrawal history",
+    icon: History,
+  },
+  {
+    href: "/support",
+    label: "Contact support",
+    description: "Get help from the Mintmine Pro team",
+    icon: HelpCircle,
+  },
+  {
+    href: "/tasks",
+    label: "Claim daily rewards",
+    description: "Complete quick actions to boost earnings",
+    icon: Send,
+  },
+]
+
+export function QuickActions() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Open quick actions"
+          className="rounded-full border border-border/80 bg-background/80 shadow-sm backdrop-blur"
+        >
+          <Bolt className="h-5 w-5" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" sideOffset={12} className="w-80 p-0">
+        <div className="border-b px-4 pb-3 pt-4">
+          <h3 className="text-sm font-semibold text-foreground">Quick actions</h3>
+          <p className="text-xs text-muted-foreground">Jump straight to the most common tasks in Mintmine Pro.</p>
+        </div>
+        <div className="flex flex-col gap-1 p-2">
+          {quickActions.map((action) => (
+            <Link
+              key={action.href}
+              href={action.href}
+              onClick={() => setOpen(false)}
+              className="group flex items-start gap-3 rounded-md px-3 py-2 text-left transition hover:bg-muted/80"
+            >
+              <action.icon className="mt-0.5 h-4 w-4 text-primary transition group-hover:scale-110" />
+              <div className="flex-1 space-y-1">
+                <p className="text-sm font-medium leading-none text-foreground">{action.label}</p>
+                <p className="text-xs text-muted-foreground">{action.description}</p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -5,8 +5,6 @@ import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
-import { NotificationBell } from "@/components/notifications/notification-bell"
-import { ThemeToggle } from "@/components/theme-toggle"
 import Image from "next/image"
 import {
   Home,
@@ -74,13 +72,6 @@ export function Sidebar({ user }: SidebarProps) {
         <div className="flex items-center space-x-2">
           <Image src="/images/logo.png" alt="Mintmine Pro" width={32} height={32} className="rounded-lg" />
           <span className="text-lg font-bold text-sidebar-foreground">Mintmine Pro</span>
-        </div>
-        <div className="mt-2 flex items-center md:hidden">
-          <div className="inline-flex items-center gap-1.5 rounded-full border border-sidebar-border/60 bg-sidebar/40 px-3 py-1.5 shadow-sm backdrop-blur-sm">
-            <NotificationBell />
-            <span className="h-4 w-px bg-sidebar-border/60" aria-hidden />
-            <ThemeToggle />
-          </div>
         </div>
       </div>
 
@@ -166,13 +157,6 @@ export function Sidebar({ user }: SidebarProps) {
         <SidebarContent />
       </div>
 
-      <div className="fixed top-8 right-6 z-[var(--z-header)] hidden md:flex">
-        <div className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/80 px-4 py-2 shadow-lg shadow-black/5 backdrop-blur">
-          <NotificationBell />
-          <span className="h-5 w-px bg-border/60" aria-hidden />
-          <ThemeToggle />
-        </div>
-      </div>
     </>
   )
 }

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,9 +1,9 @@
-'use client'
+"use client"
 
-import * as React from 'react'
-import * as PopoverPrimitive from '@radix-ui/react-popover'
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
 
-import { cn } from '@/lib/utils'
+import { cn } from "@/lib/utils"
 
 function Popover({
   ...props
@@ -19,8 +19,9 @@ function PopoverTrigger({
 
 function PopoverContent({
   className,
-  align = 'center',
+  align = "center",
   sideOffset = 4,
+  style,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
   return (
@@ -29,8 +30,10 @@ function PopoverContent({
         data-slot="popover-content"
         align={align}
         sideOffset={sideOffset}
+        collisionPadding={8}
+        style={{ position: "fixed", ...style }}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[var(--z-dropdown,900)] w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[var(--z-dropdown,900)] w-72 origin-[var(--radix-popover-content-transform-origin)] overflow-visible rounded-md border p-4 shadow-md outline-hidden",
           className,
         )}
         {...props}


### PR DESCRIPTION
## Summary
- add a global header with quick actions, theme toggle, and notifications shared across routes
- remove duplicated header controls in the admin/sidebar layouts and harden popover layering
- ensure deposit receipt URLs are absolute and render inline previews with a safe fallback link

## Testing
- pnpm lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e0c3b17083279577cb87adfee9c9