### PR TITLE
feat: redesign mobile header with drawer navigation

### DIFF
--- a/components/layout/app-header.tsx
+++ b/components/layout/app-header.tsx
@@ -1,7 +1,69 @@
 "use client"
 
-import QuickActions from "@/components/layout/quick-actions"
+import { useMemo, useRef, useState } from "react"
+import Image from "next/image"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { Menu } from "lucide-react"
+
+import QuickActions, { AUTH_HIDDEN_ROUTES } from "@/components/layout/quick-actions"
+import { MobileNavDrawer } from "@/components/layout/mobile-nav-drawer"
+import { getPageTitle } from "@/components/layout/nav-config"
+import { cn } from "@/lib/utils"
 
 export function AppHeader() {
-  return <QuickActions />
+  const pathname = usePathname() ?? "/"
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const menuButtonRef = useRef<HTMLButtonElement>(null)
+
+  const shouldHide = useMemo(
+    () => AUTH_HIDDEN_ROUTES.some((pattern) => pattern.test(pathname)),
+    [pathname],
+  )
+
+  const pageTitle = useMemo(() => getPageTitle(pathname), [pathname])
+
+  if (shouldHide) {
+    return null
+  }
+
+  return (
+    <>
+      <header
+        className="sticky top-0 z-[calc(var(--z-header)+5)] border-b border-border/50 bg-card/80 backdrop-blur supports-[backdrop-filter]:bg-card/60 shadow-sm shadow-black/5 md:hidden"
+        style={{ paddingTop: "env(safe-area-inset-top)" }}
+      >
+        <div className="flex min-h-[56px] items-center gap-3 px-3 pb-2 pt-2">
+          <button
+            ref={menuButtonRef}
+            type="button"
+            className={cn(
+              "flex size-11 shrink-0 items-center justify-center rounded-2xl border border-border/60 bg-background/60 text-foreground transition",
+              "hover:bg-muted/60 active:scale-95",
+            )}
+            aria-label="Open navigation menu"
+            aria-expanded={drawerOpen}
+            aria-controls="mobile-navigation"
+            onClick={() => setDrawerOpen(true)}
+          >
+            <Menu className="h-5 w-5" aria-hidden />
+          </button>
+
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <Link href="/dashboard" className="flex items-center gap-2" prefetch={false}>
+              <Image src="/images/logo.png" alt="Mintmine Pro" width={32} height={32} className="h-9 w-9 rounded-xl" />
+              <span className="sr-only">Go to dashboard</span>
+            </Link>
+            <span className="truncate text-sm font-medium text-foreground/90">{pageTitle}</span>
+          </div>
+
+          <QuickActions variant="mobile" mobileClassName="ml-auto" />
+        </div>
+      </header>
+
+      <QuickActions variant="desktop" />
+
+      <MobileNavDrawer open={drawerOpen} onOpenChange={setDrawerOpen} anchorRef={menuButtonRef} />
+    </>
+  )
 }

--- a/components/layout/mobile-nav-drawer.tsx
+++ b/components/layout/mobile-nav-drawer.tsx
@@ -1,0 +1,273 @@
+"use client"
+
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react"
+import Link from "next/link"
+import { usePathname, useRouter } from "next/navigation"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+
+import { PRIMARY_NAV_ITEMS, ADMIN_NAV_ITEM } from "@/components/layout/nav-config"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { cn } from "@/lib/utils"
+
+interface MobileNavDrawerProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  anchorRef: React.RefObject<HTMLButtonElement>
+}
+
+interface DrawerUser {
+  id: string
+  name: string
+  email: string
+  role: string
+  avatarUrl?: string | null
+}
+
+export function MobileNavDrawer({ open, onOpenChange, anchorRef }: MobileNavDrawerProps) {
+  const pathname = usePathname()
+  const router = useRouter()
+  const [shouldRender, setShouldRender] = useState(false)
+  const [isLoadingUser, setIsLoadingUser] = useState(false)
+  const [userError, setUserError] = useState<string | null>(null)
+  const [user, setUser] = useState<DrawerUser | null>(null)
+  const scrollYRef = useRef(0)
+  const isBodyLockedRef = useRef(false)
+  const titleId = useId()
+  const liveRegionRef = useRef<HTMLDivElement | null>(null)
+  const hasFetchedUser = useRef(false)
+
+  useEffect(() => {
+    if (open) {
+      setShouldRender(true)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (open && !hasFetchedUser.current) {
+      hasFetchedUser.current = true
+      setIsLoadingUser(true)
+      void fetch("/api/auth/me")
+        .then(async (response) => {
+          if (!response.ok) {
+            throw new Error("Failed to load user")
+          }
+          const data = (await response.json()) as { user?: DrawerUser }
+          if (data.user) {
+            setUser(data.user)
+          }
+          setUserError(null)
+        })
+        .catch((error) => {
+          console.error(error)
+          setUserError("Unable to load account details")
+        })
+        .finally(() => {
+          setIsLoadingUser(false)
+        })
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!shouldRender) {
+      return
+    }
+
+    if (liveRegionRef.current) {
+      liveRegionRef.current.textContent = open ? "Navigation drawer opened" : "Navigation drawer closed"
+    }
+  }, [open, shouldRender])
+
+  useEffect(() => {
+    const body = document.body
+
+    if (open) {
+      scrollYRef.current = window.scrollY
+      body.style.top = `-${scrollYRef.current}px`
+      body.style.position = "fixed"
+      body.style.width = "100%"
+      isBodyLockedRef.current = true
+    } else if (isBodyLockedRef.current) {
+      body.style.removeProperty("position")
+      body.style.removeProperty("top")
+      body.style.removeProperty("width")
+      window.scrollTo({ top: scrollYRef.current })
+      isBodyLockedRef.current = false
+    }
+
+    return () => {
+      body.style.removeProperty("position")
+      body.style.removeProperty("top")
+      body.style.removeProperty("width")
+      if (isBodyLockedRef.current) {
+        window.scrollTo({ top: scrollYRef.current })
+        isBodyLockedRef.current = false
+      }
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (open) {
+      onOpenChange(false)
+    }
+  }, [pathname, open, onOpenChange])
+
+  const initials = useMemo(() => {
+    if (!user?.name) {
+      return ""
+    }
+    return user.name
+      .split(" ")
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((segment) => segment.charAt(0).toUpperCase())
+      .join("")
+  }, [user?.name])
+
+  const handleLogout = useCallback(async () => {
+    try {
+      await fetch("/api/auth/logout", { method: "POST" })
+      onOpenChange(false)
+      router.push("/auth/login")
+    } catch (error) {
+      console.error("Logout error", error)
+    }
+  }, [onOpenChange, router])
+
+  const linkClasses = useCallback(
+    (isActive: boolean) =>
+      cn(
+        "flex items-center gap-3 rounded-2xl px-3 py-3 text-base font-medium transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "ring-offset-background",
+        isActive
+          ? "bg-primary/15 text-primary"
+          : "text-foreground hover:bg-muted/70 hover:text-foreground",
+      ),
+    [],
+  )
+
+  const renderNavItems = () => (
+    <ul className="space-y-1">
+      {PRIMARY_NAV_ITEMS.map((item) => {
+        const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`)
+        return (
+          <li key={item.href}>
+            <Link
+              href={item.href}
+              onClick={() => onOpenChange(false)}
+              className={linkClasses(isActive)}
+              aria-current={isActive ? "page" : undefined}
+            >
+              <item.icon className="h-5 w-5" aria-hidden />
+              <span className="truncate">{item.name}</span>
+            </Link>
+          </li>
+        )
+      })}
+      {user?.role === "admin" && (
+        <li key={ADMIN_NAV_ITEM.href}>
+          <Link
+            href={ADMIN_NAV_ITEM.href}
+            onClick={() => onOpenChange(false)}
+            className={linkClasses(
+              pathname === ADMIN_NAV_ITEM.href || pathname.startsWith(`${ADMIN_NAV_ITEM.href}/`),
+            )}
+            aria-current={
+              pathname === ADMIN_NAV_ITEM.href || pathname.startsWith(`${ADMIN_NAV_ITEM.href}/`)
+                ? "page"
+                : undefined
+            }
+          >
+            <ADMIN_NAV_ITEM.icon className="h-5 w-5" aria-hidden />
+            <span className="truncate">{ADMIN_NAV_ITEM.name}</span>
+          </Link>
+        </li>
+      )}
+    </ul>
+  )
+
+  if (!shouldRender) {
+    return null
+  }
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-[var(--z-header)] bg-background/60 opacity-0 transition-opacity duration-[240ms] ease-[cubic-bezier(.2,.8,.2,1)] data-[state=open]:opacity-60" />
+        <DialogPrimitive.Content
+          id="mobile-navigation"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          onCloseAutoFocus={(event) => {
+            event.preventDefault()
+            anchorRef.current?.focus()
+          }}
+          className={cn(
+            "pointer-events-auto fixed inset-y-0 left-0 z-[calc(var(--z-header)+1)] flex h-dvh min-w-[80vw] max-w-[92vw] flex-col overflow-hidden rounded-r-3xl border-r border-border/60 bg-card/95 text-card-foreground shadow-2xl shadow-black/20 backdrop-blur supports-[backdrop-filter]:bg-card/80 will-change-[transform,opacity]",
+            "transition-[transform,opacity] duration-[240ms] ease-[cubic-bezier(.2,.8,.2,1)]",
+            "data-[state=closed]:-translate-x-6 data-[state=closed]:scale-[0.98] data-[state=closed]:opacity-0",
+            "data-[state=open]:translate-x-0 data-[state=open]:scale-100 data-[state=open]:opacity-100",
+          )}
+        >
+          <div className="flex h-full flex-col">
+            <div className="space-y-4 px-5 pb-4 pt-[calc(env(safe-area-inset-top)+1rem)]">
+              <DialogPrimitive.Title id={titleId} className="sr-only">
+                Mobile navigation
+              </DialogPrimitive.Title>
+              <div className="flex items-center gap-3">
+                <Avatar className="h-12 w-12">
+                  {user?.avatarUrl ? (
+                    <AvatarImage src={user.avatarUrl} alt={user.name ?? "User avatar"} />
+                  ) : (
+                    <AvatarFallback className="text-base font-semibold">{initials || "?"}</AvatarFallback>
+                  )}
+                </Avatar>
+                <div className="min-w-0 flex-1">
+                  <p className="text-base font-semibold leading-tight truncate">
+                    {user?.name ?? (isLoadingUser ? "Loading..." : "Guest")}
+                  </p>
+                  <p className="text-sm text-muted-foreground truncate">
+                    {user?.email ?? (userError ? "Sign in required" : "")}
+                  </p>
+                </div>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-10 rounded-xl px-4 text-sm font-medium"
+                asChild
+              >
+                <Link href="/profile" onClick={() => onOpenChange(false)}>
+                  View Profile
+                </Link>
+              </Button>
+            </div>
+
+            <Separator className="border-border/60" />
+
+            <div className="flex-1 overflow-y-auto px-4 py-4">
+              {renderNavItems()}
+            </div>
+
+            <Separator className="border-border/60" />
+
+            <div className="px-5 pb-[calc(env(safe-area-inset-bottom)+1rem)] pt-4">
+              <Button
+                variant="ghost"
+                className="w-full justify-start rounded-2xl px-4 py-3 text-base font-medium"
+                onClick={() => {
+                  void handleLogout()
+                }}
+              >
+                Sign out
+              </Button>
+            </div>
+          </div>
+        </DialogPrimitive.Content>
+        <div ref={liveRegionRef} className="sr-only" aria-live="polite" />
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  )
+}

--- a/components/layout/nav-config.ts
+++ b/components/layout/nav-config.ts
@@ -1,0 +1,69 @@
+import type { LucideIcon } from "lucide-react"
+import {
+  BarChart3,
+  Coins,
+  CreditCard,
+  FileText,
+  HelpCircle,
+  History,
+  Home,
+  Pickaxe,
+  Settings,
+  User,
+  Users,
+  Wallet,
+} from "lucide-react"
+
+export type AppNavItem = {
+  name: string
+  href: string
+  icon: LucideIcon
+}
+
+export const PRIMARY_NAV_ITEMS: AppNavItem[] = [
+  { name: "Home", href: "/dashboard", icon: Home },
+  { name: "Mining", href: "/mining", icon: Pickaxe },
+  { name: "Wallet", href: "/wallet", icon: Wallet },
+  { name: "Task", href: "/tasks", icon: BarChart3 },
+  { name: "Team", href: "/team", icon: Users },
+  { name: "List Coin", href: "/coins", icon: Coins },
+  { name: "E-Wallet", href: "/e-wallet", icon: CreditCard },
+  { name: "History", href: "/transactions", icon: History },
+  { name: "Support", href: "/support", icon: HelpCircle },
+  { name: "Profile", href: "/profile", icon: User },
+  { name: "Terms", href: "/terms", icon: FileText },
+]
+
+export const ADMIN_NAV_ITEM: AppNavItem = {
+  name: "Admin Panel",
+  href: "/admin",
+  icon: Settings,
+}
+
+const PAGE_TITLE_RULES: Array<{ pattern: RegExp; title: string }> = [
+  { pattern: /^\/$/, title: "Welcome" },
+  { pattern: /^\/dashboard(?:\/.+)?$/, title: "Dashboard" },
+  { pattern: /^\/mining(?:\/.+)?$/, title: "Mining" },
+  { pattern: /^\/wallet(?:\/.+)?$/, title: "Wallet" },
+  { pattern: /^\/e-wallet(?:\/.+)?$/, title: "E-Wallet" },
+  { pattern: /^\/transactions(?:\/.+)?$/, title: "History" },
+  { pattern: /^\/tasks(?:\/.+)?$/, title: "Tasks" },
+  { pattern: /^\/team(?:\/.+)?$/, title: "Team" },
+  { pattern: /^\/coins(?:\/.+)?$/, title: "Coin Listings" },
+  { pattern: /^\/support(?:\/.+)?$/, title: "Support" },
+  { pattern: /^\/profile(?:\/.+)?$/, title: "Profile" },
+  { pattern: /^\/terms(?:\/.+)?$/, title: "Terms" },
+  { pattern: /^\/admin(?:\/.+)?$/, title: "Admin Panel" },
+]
+
+export function getPageTitle(pathname: string): string {
+  const match = PAGE_TITLE_RULES.find(({ pattern }) => pattern.test(pathname))
+  if (match) {
+    return match.title
+  }
+
+  const fallback = PRIMARY_NAV_ITEMS.find((item) =>
+    pathname === item.href || pathname.startsWith(`${item.href}/`),
+  )
+  return fallback?.name ?? "Mintmine Pro"
+}

--- a/components/layout/quick-actions.tsx
+++ b/components/layout/quick-actions.tsx
@@ -5,8 +5,9 @@ import { usePathname } from "next/navigation"
 
 import { NotificationBell } from "@/components/notifications/notification-bell"
 import { ThemeToggle } from "@/components/theme-toggle"
+import { cn } from "@/lib/utils"
 
-const AUTH_HIDDEN_ROUTES = [
+export const AUTH_HIDDEN_ROUTES = [
   /^\/login(?:\/.*)?$/,
   /^\/signin(?:\/.*)?$/,
   /^\/signup(?:\/.*)?$/,
@@ -14,7 +15,14 @@ const AUTH_HIDDEN_ROUTES = [
   /^\/auth\/(?:login|register|forgot|verify-otp)(?:\/.*)?$/,
 ]
 
-export default function QuickActions() {
+type QuickActionsVariant = "mobile" | "desktop" | "both"
+
+type QuickActionsProps = {
+  mobileClassName?: string
+  variant?: QuickActionsVariant
+}
+
+export default function QuickActions({ mobileClassName, variant = "both" }: QuickActionsProps = {}) {
   const pathname = usePathname() ?? "/"
 
   const shouldHide = useMemo(
@@ -26,13 +34,37 @@ export default function QuickActions() {
     return null
   }
 
-  return (
-    <div className="pointer-events-none fixed right-4 top-4 z-[var(--z-header)] flex w-full justify-end px-2 sm:right-6 sm:top-6">
-      <div className="pointer-events-auto flex items-center gap-3 rounded-2xl border border-border/70 bg-card/80 px-3 py-2 shadow-lg shadow-black/5 backdrop-blur">
-        <NotificationBell />
-        <span className="h-5 w-px bg-border/60" aria-hidden />
-        <ThemeToggle />
-      </div>
+  const showMobile = variant === "mobile" || variant === "both"
+  const showDesktop = variant === "desktop" || variant === "both"
+
+  const renderActions = () => (
+    <div className="flex items-center gap-2 md:gap-3">
+      <NotificationBell />
+      <span className="hidden h-5 w-px bg-border/60 md:block" aria-hidden />
+      <ThemeToggle />
     </div>
+  )
+
+  return (
+    <>
+      {showMobile ? (
+        <div
+          className={cn(
+            "md:hidden flex items-center rounded-2xl border border-border/60 bg-card/80 px-2 py-1 text-sm shadow-sm shadow-black/5 backdrop-blur supports-[backdrop-filter]:bg-card/60",
+            mobileClassName,
+          )}
+        >
+          {renderActions()}
+        </div>
+      ) : null}
+
+      {showDesktop ? (
+        <div className="pointer-events-none hidden md:fixed md:right-4 md:top-4 md:z-[var(--z-header)] md:flex md:w-full md:justify-end md:px-2 lg:right-6 lg:top-6">
+          <div className="pointer-events-auto flex items-center gap-3 rounded-2xl border border-border/70 bg-card/80 px-3 py-2 shadow-lg shadow-black/5 backdrop-blur supports-[backdrop-filter]:bg-card/60">
+            {renderActions()}
+          </div>
+        </div>
+      ) : null}
+    </>
   )
 }

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -3,40 +3,12 @@
 import { useEffect, useState } from "react"
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
+import Image from "next/image"
+import { Menu, LogOut } from "lucide-react"
+
+import { PRIMARY_NAV_ITEMS, ADMIN_NAV_ITEM } from "@/components/layout/nav-config"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
-import Image from "next/image"
-import {
-  Home,
-  BarChart3,
-  Users,
-  Coins,
-  Pickaxe,
-  TrendingUp,
-  Wallet,
-  CreditCard,
-  History,
-  HelpCircle,
-  User,
-  FileText,
-  Menu,
-  LogOut,
-  Settings,
-} from "lucide-react"
-
-const navigation = [
-  { name: "Home", href: "/dashboard", icon: Home },
-  { name: "Mining", href: "/mining", icon: Pickaxe },
-  { name: "Wallet", href: "/wallet", icon: Wallet },
-  { name: "Task", href: "/tasks", icon: BarChart3 },
-  { name: "Team", href: "/team", icon: Users },
-  { name: "List Coin", href: "/coins", icon: Coins },
-  { name: "E-Wallet", href: "/e-wallet", icon: CreditCard },
-  { name: "History", href: "/transactions", icon: History },
-  { name: "Support", href: "/support", icon: HelpCircle },
-  { name: "Profile", href: "/profile", icon: User },
-  { name: "Terms", href: "/terms", icon: FileText },
-]
 
 interface SidebarProps {
   user?: {
@@ -77,7 +49,7 @@ export function Sidebar({ user }: SidebarProps) {
 
       {/* Navigation */}
       <nav className="flex-1 space-y-1 px-3 py-4">
-        {navigation.map((item) => {
+        {PRIMARY_NAV_ITEMS.map((item) => {
           const isActive =
             pathname === item.href || pathname.startsWith(`${item.href}/`)
           return (
@@ -99,18 +71,18 @@ export function Sidebar({ user }: SidebarProps) {
 
         {user?.role === "admin" && (
           <Link
-            href="/admin"
+            href={ADMIN_NAV_ITEM.href}
             className={`flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
-              pathname === "/admin" || pathname.startsWith("/admin/")
+              pathname === ADMIN_NAV_ITEM.href || pathname.startsWith(`${ADMIN_NAV_ITEM.href}/`)
                 ? "bg-sidebar-accent text-sidebar-accent-foreground"
                 : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
             }`}
             onClick={() => setOpen(false)}
           >
-            <Settings className="mr-3 h-5 w-5" />
-            Admin Panel
+            <ADMIN_NAV_ITEM.icon className="mr-3 h-5 w-5" />
+            {ADMIN_NAV_ITEM.name}
           </Link>
-         )} 
+        )}
       </nav>
 
       {/* User info and logout */}


### PR DESCRIPTION
## Summary
- implement a mobile-only sticky header with hamburger trigger, logo, page title, and inline quick actions
- refactor quick actions and navigation config for reuse between the sidebar and the new drawer experience
- add an animated mobile navigation drawer with lazy user loading, scroll locking, and accessible focus management

## Testing
- npm run lint *(fails: interactive configuration prompt from Next.js lint)*

------
https://chatgpt.com/codex/tasks/task_e_68e434b278c8832785541c4a303d3dc4