### PR TITLE
Refine mobile navigation drawer

### DIFF
--- a/components/layout/app-header.tsx
+++ b/components/layout/app-header.tsx
@@ -30,7 +30,7 @@ export function AppHeader() {
   return (
     <>
       <header
-        className="sticky top-0 z-[calc(var(--z-header)+5)] border-b border-border/50 bg-card/80 backdrop-blur supports-[backdrop-filter]:bg-card/60 shadow-sm shadow-black/5 md:hidden"
+        className="sticky top-0 z-[100] border-b border-border/50 bg-card/80 backdrop-blur supports-[backdrop-filter]:bg-card/60 shadow-sm shadow-black/5 md:hidden"
         style={{ paddingTop: "env(safe-area-inset-top)" }}
       >
         <div className="flex min-h-[56px] items-center gap-3 px-3 pb-2 pt-2">
@@ -41,9 +41,9 @@ export function AppHeader() {
               "flex size-11 shrink-0 items-center justify-center rounded-2xl border border-border/60 bg-background/60 text-foreground transition",
               "hover:bg-muted/60 active:scale-95",
             )}
-            aria-label="Open navigation menu"
+            aria-label="Open menu"
             aria-expanded={drawerOpen}
-            aria-controls="mobile-navigation"
+            aria-controls="mobile-drawer"
             onClick={() => setDrawerOpen(true)}
           >
             <Menu className="h-5 w-5" aria-hidden />

--- a/components/layout/mobile-nav-drawer.tsx
+++ b/components/layout/mobile-nav-drawer.tsx
@@ -195,9 +195,9 @@ export function MobileNavDrawer({ open, onOpenChange, anchorRef }: MobileNavDraw
   return (
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-[var(--z-header)] bg-background/60 opacity-0 transition-opacity duration-[240ms] ease-[cubic-bezier(.2,.8,.2,1)] data-[state=open]:opacity-60" />
+        <DialogPrimitive.Overlay className="fixed inset-0 z-[900] bg-black/50 opacity-0 transition-opacity duration-[240ms] ease-[cubic-bezier(.2,.8,.2,1)] data-[state=open]:opacity-100" />
         <DialogPrimitive.Content
-          id="mobile-navigation"
+          id="mobile-drawer"
           aria-modal="true"
           aria-labelledby={titleId}
           onCloseAutoFocus={(event) => {
@@ -205,7 +205,7 @@ export function MobileNavDrawer({ open, onOpenChange, anchorRef }: MobileNavDraw
             anchorRef.current?.focus()
           }}
           className={cn(
-            "pointer-events-auto fixed inset-y-0 left-0 z-[calc(var(--z-header)+1)] flex h-dvh min-w-[80vw] max-w-[92vw] flex-col overflow-hidden rounded-r-3xl border-r border-border/60 bg-card/95 text-card-foreground shadow-2xl shadow-black/20 backdrop-blur supports-[backdrop-filter]:bg-card/80 will-change-[transform,opacity]",
+            "pointer-events-auto fixed left-0 top-0 z-[1000] flex h-screen w-[86vw] flex-col overflow-hidden border-r border-border/60 bg-card text-card-foreground shadow-2xl shadow-black/20 will-change-[transform,opacity]",
             "transition-[transform,opacity] duration-[240ms] ease-[cubic-bezier(.2,.8,.2,1)]",
             "data-[state=closed]:-translate-x-6 data-[state=closed]:scale-[0.98] data-[state=closed]:opacity-0",
             "data-[state=open]:translate-x-0 data-[state=open]:scale-100 data-[state=open]:opacity-100",

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -1,14 +1,12 @@
 "use client"
 
-import { useEffect, useState } from "react"
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
 import Image from "next/image"
-import { Menu, LogOut } from "lucide-react"
+import { LogOut } from "lucide-react"
 
 import { PRIMARY_NAV_ITEMS, ADMIN_NAV_ITEM } from "@/components/layout/nav-config"
 import { Button } from "@/components/ui/button"
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 
 interface SidebarProps {
   user?: {
@@ -22,11 +20,6 @@ interface SidebarProps {
 export function Sidebar({ user }: SidebarProps) {
   const pathname = usePathname()
   const router = useRouter()
-  const [open, setOpen] = useState(false)
-
-  useEffect(() => {
-    setOpen(false)
-  }, [pathname])
 
   const handleLogout = async () => {
     try {
@@ -61,7 +54,6 @@ export function Sidebar({ user }: SidebarProps) {
                   ? "bg-sidebar-accent text-sidebar-accent-foreground"
                   : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
               }`}
-              onClick={() => setOpen(false)}
             >
               <item.icon className="mr-3 h-5 w-5" />
               {item.name}
@@ -77,7 +69,6 @@ export function Sidebar({ user }: SidebarProps) {
                 ? "bg-sidebar-accent text-sidebar-accent-foreground"
                 : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
             }`}
-            onClick={() => setOpen(false)}
           >
             <ADMIN_NAV_ITEM.icon className="mr-3 h-5 w-5" />
             {ADMIN_NAV_ITEM.name}
@@ -97,7 +88,6 @@ export function Sidebar({ user }: SidebarProps) {
             variant="ghost"
             size="sm"
             onClick={() => {
-              setOpen(false)
               void handleLogout()
             }}
             className="w-full justify-start text-sidebar-foreground "
@@ -111,24 +101,8 @@ export function Sidebar({ user }: SidebarProps) {
   )
 
   return (
-    <>
-      {/* Mobile sidebar */}
-      <Sheet open={open} onOpenChange={setOpen}>
-        <SheetTrigger asChild>
-          <Button variant="ghost" size="icon" className="md:hidden h-14 w-14">
-            <Menu className="h-10 w-10" />
-          </Button>
-        </SheetTrigger>
-        <SheetContent side="left" className="w-64 p-0 [&_[data-slot='sheet-close']]:hidden">
-          <SidebarContent />
-        </SheetContent>
-      </Sheet>
-
-      {/* Desktop sidebar */}
-      <div className="hidden md:flex md:w-64 md:flex-col md:fixed md:inset-y-0">
-        <SidebarContent />
-      </div>
-
-    </>
+    <aside className="hidden md:fixed md:inset-y-0 md:flex md:w-64 md:flex-col">
+      <SidebarContent />
+    </aside>
   )
 }


### PR DESCRIPTION
## Summary
- remove the legacy mobile sheet trigger from the sidebar so only the header hamburger controls navigation
- update the header trigger aria wiring and stacking order while preserving desktop quick actions
- restyle the mobile drawer/backdrop animation to slide in from the left with the requested dimensions and opacity easing

## Testing
- npm run lint *(fails: command prompts for configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e43b148ae08327b2ada86b372483f8