### PR TITLE
Fix mobile menu drawer closing immediately

### DIFF
--- a/components/layout/mobile-nav-drawer.tsx
+++ b/components/layout/mobile-nav-drawer.tsx
@@ -107,9 +107,15 @@ export function MobileNavDrawer({ open, onOpenChange, anchorRef }: MobileNavDraw
     }
   }, [open])
 
+  const previousPathnameRef = useRef(pathname)
+
   useEffect(() => {
-    if (open) {
-      onOpenChange(false)
+    if (pathname !== previousPathnameRef.current) {
+      previousPathnameRef.current = pathname
+
+      if (open) {
+        onOpenChange(false)
+      }
     }
   }, [pathname, open, onOpenChange])
 


### PR DESCRIPTION
## Summary
- ensure the mobile navigation drawer only closes in response to a route change so the menu button opens the sidebar correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e43e73a49c83279997c78daa06efa0