### PR TITLE
Add blind box lucky draw investment system

### DIFF
--- a/app/api/admin/blindbox/deposits/[id]/approve/route.ts
+++ b/app/api/admin/blindbox/deposits/[id]/approve/route.ts
@@ -1,0 +1,35 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { getUserFromRequest } from "@/lib/auth"
+import { BlindBoxServiceError, approveBlindBoxDeposit } from "@/lib/services/blindbox"
+import User from "@/models/User"
+
+export async function POST(_request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const payload = getUserFromRequest(_request)
+    if (!payload) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const adminUser = await User.findById(payload.userId).select("role")
+    if (!adminUser || adminUser.role !== "admin") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const depositId = params.id
+    if (!depositId) {
+      return NextResponse.json({ error: "Deposit ID is required" }, { status: 400 })
+    }
+
+    await approveBlindBoxDeposit({ depositId, adminId: payload.userId })
+
+    return NextResponse.json({ success: true })
+  } catch (error: any) {
+    if (error instanceof BlindBoxServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error("Admin approve blind box deposit error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/app/api/admin/blindbox/deposits/[id]/reject/route.ts
+++ b/app/api/admin/blindbox/deposits/[id]/reject/route.ts
@@ -1,0 +1,38 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { getUserFromRequest } from "@/lib/auth"
+import { BlindBoxServiceError, rejectBlindBoxDeposit } from "@/lib/services/blindbox"
+import User from "@/models/User"
+
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const payload = getUserFromRequest(request)
+    if (!payload) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const adminUser = await User.findById(payload.userId).select("role")
+    if (!adminUser || adminUser.role !== "admin") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const depositId = params.id
+    if (!depositId) {
+      return NextResponse.json({ error: "Deposit ID is required" }, { status: 400 })
+    }
+
+    const body = await request.json().catch(() => ({}))
+    const reason = typeof body.reason === "string" ? body.reason.slice(0, 500) : undefined
+
+    await rejectBlindBoxDeposit({ depositId, adminId: payload.userId, reason })
+
+    return NextResponse.json({ success: true })
+  } catch (error: any) {
+    if (error instanceof BlindBoxServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error("Admin reject blind box deposit error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/app/api/admin/blindbox/deposits/route.ts
+++ b/app/api/admin/blindbox/deposits/route.ts
@@ -1,0 +1,56 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { getUserFromRequest } from "@/lib/auth"
+import { BlindBoxServiceError, listBlindBoxDeposits } from "@/lib/services/blindbox"
+import User from "@/models/User"
+
+export async function GET(request: NextRequest) {
+  try {
+    const payload = getUserFromRequest(request)
+    if (!payload) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const adminUser = await User.findById(payload.userId).select("role")
+    if (!adminUser || adminUser.role !== "admin") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const statusParam = searchParams.get("status")
+
+    const deposits = await listBlindBoxDeposits(
+      statusParam === "pending" || statusParam === "approved" || statusParam === "rejected"
+        ? (statusParam as any)
+        : undefined,
+    )
+
+    const normalized = deposits.map((deposit) => ({
+      id: deposit._id.toString(),
+      status: deposit.status,
+      txId: deposit.txId,
+      amount: deposit.amount,
+      network: deposit.network,
+      address: deposit.address,
+      createdAt: deposit.createdAt.toISOString(),
+      user:
+        deposit.userId && typeof deposit.userId === "object" && "_id" in deposit.userId
+          ? {
+              id: (deposit.userId as any)._id.toString(),
+              name: (deposit.userId as any).name ?? "",
+              email: (deposit.userId as any).email ?? "",
+              referralCode: (deposit.userId as any).referralCode ?? "",
+            }
+          : null,
+    }))
+
+    return NextResponse.json({ deposits: normalized })
+  } catch (error: any) {
+    if (error instanceof BlindBoxServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error("Admin blind box deposits error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/app/api/admin/blindbox/overview/route.ts
+++ b/app/api/admin/blindbox/overview/route.ts
@@ -1,0 +1,30 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { getUserFromRequest } from "@/lib/auth"
+import { BlindBoxServiceError, getBlindBoxAdminSummary } from "@/lib/services/blindbox"
+import User from "@/models/User"
+
+export async function GET(request: NextRequest) {
+  try {
+    const payload = getUserFromRequest(request)
+    if (!payload) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const adminUser = await User.findById(payload.userId).select("role")
+    if (!adminUser || adminUser.role !== "admin") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const summary = await getBlindBoxAdminSummary()
+
+    return NextResponse.json(summary)
+  } catch (error: any) {
+    if (error instanceof BlindBoxServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error("Admin blind box overview error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/app/api/admin/blindbox/round/[id]/draw/route.ts
+++ b/app/api/admin/blindbox/round/[id]/draw/route.ts
@@ -1,0 +1,50 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { getUserFromRequest } from "@/lib/auth"
+import { BlindBoxServiceError, finalizeBlindBoxRound } from "@/lib/services/blindbox"
+import User from "@/models/User"
+
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const payload = getUserFromRequest(request)
+    if (!payload) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const adminUser = await User.findById(payload.userId).select("role")
+    if (!adminUser || adminUser.role !== "admin") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const roundId = params.id
+    if (!roundId) {
+      return NextResponse.json({ error: "Round ID is required" }, { status: 400 })
+    }
+
+    const body = await request.json().catch(() => ({}))
+    const winnerId = typeof body.winnerId === "string" ? body.winnerId : undefined
+
+    const round = await finalizeBlindBoxRound(roundId, {
+      trigger: "manual",
+      winnerId,
+      startNextRound: body.startNextRound !== false,
+    })
+
+    return NextResponse.json({
+      round: round
+        ? {
+            id: round._id.toString(),
+            status: round.status,
+            winnerUserId: round.winnerUserId ? round.winnerUserId.toString() : null,
+          }
+        : null,
+    })
+  } catch (error: any) {
+    if (error instanceof BlindBoxServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error("Admin blind box draw error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/app/api/admin/blindbox/rounds/route.ts
+++ b/app/api/admin/blindbox/rounds/route.ts
@@ -1,0 +1,33 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { getUserFromRequest } from "@/lib/auth"
+import { BlindBoxServiceError, listBlindBoxRounds } from "@/lib/services/blindbox"
+import User from "@/models/User"
+
+export async function GET(request: NextRequest) {
+  try {
+    const payload = getUserFromRequest(request)
+    if (!payload) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const adminUser = await User.findById(payload.userId).select("role")
+    if (!adminUser || adminUser.role !== "admin") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const limit = Number.parseInt(searchParams.get("limit") ?? "20")
+
+    const rounds = await listBlindBoxRounds(Number.isFinite(limit) ? Math.min(Math.max(limit, 1), 200) : 20)
+
+    return NextResponse.json({ rounds })
+  } catch (error: any) {
+    if (error instanceof BlindBoxServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error("Admin blind box rounds error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/app/api/admin/blindbox/settings/route.ts
+++ b/app/api/admin/blindbox/settings/route.ts
@@ -1,0 +1,61 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { getUserFromRequest } from "@/lib/auth"
+import { BlindBoxServiceError, getBlindBoxConfig, updateBlindBoxSettings } from "@/lib/services/blindbox"
+import User from "@/models/User"
+
+export async function GET(request: NextRequest) {
+  try {
+    const payload = getUserFromRequest(request)
+    if (!payload) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const adminUser = await User.findById(payload.userId).select("role")
+    if (!adminUser || adminUser.role !== "admin") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const config = await getBlindBoxConfig()
+
+    return NextResponse.json({ config })
+  } catch (error: any) {
+    if (error instanceof BlindBoxServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error("Admin blind box settings fetch error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const payload = getUserFromRequest(request)
+    if (!payload) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const adminUser = await User.findById(payload.userId).select("role")
+    if (!adminUser || adminUser.role !== "admin") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const body = await request.json().catch(() => ({}))
+    const nextConfig = await updateBlindBoxSettings({
+      depositAmount: typeof body.depositAmount === "number" ? body.depositAmount : undefined,
+      rewardAmount: typeof body.rewardAmount === "number" ? body.rewardAmount : undefined,
+      cycleHours: typeof body.cycleHours === "number" ? body.cycleHours : undefined,
+      autoDrawEnabled: typeof body.autoDrawEnabled === "boolean" ? body.autoDrawEnabled : undefined,
+    })
+
+    return NextResponse.json({ config: nextConfig })
+  } catch (error: any) {
+    if (error instanceof BlindBoxServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error("Admin blind box settings update error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/app/api/blindbox/deposit/route.ts
+++ b/app/api/blindbox/deposit/route.ts
@@ -1,0 +1,37 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { getUserFromRequest } from "@/lib/auth"
+import { BlindBoxServiceError, submitBlindBoxDeposit } from "@/lib/services/blindbox"
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = getUserFromRequest(request)
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const payload = await request.json().catch(() => null)
+    if (!payload || typeof payload.txId !== "string") {
+      return NextResponse.json({ error: "Transaction hash is required" }, { status: 400 })
+    }
+
+    const deposit = await submitBlindBoxDeposit({ userId: user.userId, txId: payload.txId })
+
+    return NextResponse.json({
+      deposit: {
+        id: deposit._id.toString(),
+        status: deposit.status,
+        txId: deposit.txId,
+        amount: deposit.amount,
+        createdAt: deposit.createdAt.toISOString(),
+      },
+    })
+  } catch (error: any) {
+    if (error instanceof BlindBoxServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error("Blind box deposit submission error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/app/api/blindbox/round/ensure/route.ts
+++ b/app/api/blindbox/round/ensure/route.ts
@@ -1,0 +1,24 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { runBlindBoxAutoDraw } from "@/lib/services/blindbox"
+
+export const dynamic = "force-dynamic"
+
+export async function POST(_request: NextRequest) {
+  try {
+    const round = await runBlindBoxAutoDraw()
+    return NextResponse.json({
+      round: round
+        ? {
+            id: round._id.toString(),
+            status: round.status,
+            endTime: round.endTime.toISOString(),
+            totalParticipants: round.totalParticipants,
+          }
+        : null,
+    })
+  } catch (error) {
+    console.error("Blind box ensure round error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/app/api/blindbox/rounds/route.ts
+++ b/app/api/blindbox/rounds/route.ts
@@ -1,0 +1,27 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { getUserFromRequest } from "@/lib/auth"
+import { BlindBoxServiceError, listBlindBoxRounds } from "@/lib/services/blindbox"
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = getUserFromRequest(request)
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const limit = Number.parseInt(searchParams.get("limit") ?? "10")
+
+    const rounds = await listBlindBoxRounds(Number.isFinite(limit) ? Math.min(Math.max(limit, 1), 50) : 10)
+
+    return NextResponse.json({ rounds })
+  } catch (error: any) {
+    if (error instanceof BlindBoxServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error("Blind box rounds history error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/app/api/blindbox/summary/route.ts
+++ b/app/api/blindbox/summary/route.ts
@@ -1,0 +1,36 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { getUserFromRequest } from "@/lib/auth"
+import {
+  BLIND_BOX_CONSTANTS,
+  BlindBoxServiceError,
+  getBlindBoxSummaryForUser,
+} from "@/lib/services/blindbox"
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = getUserFromRequest(request)
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const summary = await getBlindBoxSummaryForUser(user.userId)
+
+    return NextResponse.json({
+      round: summary.round,
+      previousRound: summary.previousRound,
+      nextDrawAt: summary.nextDrawAt,
+      participants: summary.participants,
+      config: summary.config,
+      userStatus: summary.userStatus,
+      constants: BLIND_BOX_CONSTANTS,
+    })
+  } catch (error: any) {
+    if (error instanceof BlindBoxServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error("Blind box summary error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/app/blind-box/page.tsx
+++ b/app/blind-box/page.tsx
@@ -1,0 +1,48 @@
+import { cookies } from "next/headers"
+import { redirect } from "next/navigation"
+
+import { BlindBoxDashboard } from "@/components/blindbox/blind-box-dashboard"
+import { Sidebar } from "@/components/layout/sidebar"
+import { BLIND_BOX_CONSTANTS, getBlindBoxSummaryForUser, listBlindBoxRounds } from "@/lib/services/blindbox"
+import { fetchWalletContext } from "@/lib/services/wallet"
+import { verifyToken } from "@/lib/auth"
+
+export const dynamic = "force-dynamic"
+
+export default async function BlindBoxPage() {
+  const cookieStore = await cookies()
+  const token = cookieStore.get("auth-token")?.value
+  if (!token) {
+    redirect("/auth/login")
+  }
+
+  const session = await verifyToken(token)
+  if (!session) {
+    redirect("/auth/login")
+  }
+
+  const [walletContext, summary, history] = await Promise.all([
+    fetchWalletContext(session.userId),
+    getBlindBoxSummaryForUser(session.userId),
+    listBlindBoxRounds(10),
+  ])
+
+  if (!walletContext) {
+    redirect("/auth/login")
+  }
+
+  return (
+    <div className="flex min-h-screen bg-slate-950 text-white">
+      <Sidebar user={walletContext.user} />
+      <main className="relative flex-1 overflow-y-auto md:ml-64">
+        <div className="relative mx-auto flex w-full max-w-5xl flex-col gap-8 px-6 py-10 md:px-10">
+          <BlindBoxDashboard
+            initialSummary={summary}
+            constants={BLIND_BOX_CONSTANTS}
+            initialHistory={history}
+          />
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/components/admin/admin-dashboard.tsx
+++ b/components/admin/admin-dashboard.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from "@/components/layout/sidebar"
 import { TransactionTable } from "@/components/admin/transaction-table"
 import { UserTable } from "@/components/admin/user-table"
 import { LuckyDrawPanel } from "@/components/admin/lucky-draw-panel"
+import { BlindBoxAdminPanel } from "@/components/admin/blind-box-panel"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -208,11 +209,12 @@ export function AdminDashboard({
           )}
 
           <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-            <TabsList className="grid w-full grid-cols-4">
+            <TabsList className="grid w-full grid-cols-5">
               <TabsTrigger value="overview">Overview</TabsTrigger>
               <TabsTrigger value="transactions">Transactions</TabsTrigger>
               <TabsTrigger value="users">Users</TabsTrigger>
               <TabsTrigger value="lucky-draw">Lucky Draw</TabsTrigger>
+              <TabsTrigger value="blind-box">Blind Box</TabsTrigger>
             </TabsList>
 
             <TabsContent value="overview" className="space-y-6">
@@ -339,6 +341,9 @@ export function AdminDashboard({
             </TabsContent>
             <TabsContent value="lucky-draw">
               <LuckyDrawPanel />
+            </TabsContent>
+            <TabsContent value="blind-box">
+              <BlindBoxAdminPanel />
             </TabsContent>
           </Tabs>
 

--- a/components/admin/blind-box-panel.tsx
+++ b/components/admin/blind-box-panel.tsx
@@ -1,0 +1,599 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { Loader2, RefreshCcw, ShieldCheck, Sparkles, Users, Zap } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Textarea } from "@/components/ui/textarea"
+import { useToast } from "@/components/ui/use-toast"
+import { Badge } from "@/components/ui/badge"
+import { ScrollArea } from "@/components/ui/scroll-area"
+
+interface AdminBlindBoxConfig {
+  depositAmount: number
+  rewardAmount: number
+  cycleHours: number
+  autoDrawEnabled: boolean
+}
+
+interface AdminBlindBoxDeposit {
+  id: string
+  txId: string
+  amount: number
+  network: string
+  address: string
+  createdAt: string
+  status: "pending" | "approved" | "rejected"
+  user: {
+    id: string
+    name: string
+    email: string
+    referralCode: string
+  } | null
+}
+
+interface AdminBlindBoxParticipant {
+  id: string
+  user: {
+    id: string
+    name: string
+    email: string
+    referralCode: string
+  } | null
+  joinedAt: string
+  status: "active" | "eliminated"
+  hashedUserId: string
+}
+
+interface AdminBlindBoxRoundSummary {
+  id: string
+  startTime: string
+  endTime: string
+  status: "open" | "completed"
+  totalParticipants: number
+  rewardAmount: number
+  depositAmount: number
+  winnerSnapshot?: {
+    name: string
+    referralCode?: string | null
+    email?: string | null
+    creditedAt?: string | null
+  } | null
+}
+
+interface AdminBlindBoxOverview {
+  round: AdminBlindBoxRoundSummary | null
+  previousRound: AdminBlindBoxRoundSummary | null
+  participants: AdminBlindBoxParticipant[]
+  pendingDeposits: AdminBlindBoxDeposit[]
+  config: AdminBlindBoxConfig
+}
+
+export function BlindBoxAdminPanel() {
+  const { toast } = useToast()
+  const [loading, setLoading] = useState(false)
+  const [overview, setOverview] = useState<AdminBlindBoxOverview | null>(null)
+  const [history, setHistory] = useState<AdminBlindBoxRoundSummary[]>([])
+  const [settingsDraft, setSettingsDraft] = useState<AdminBlindBoxConfig>({
+    depositAmount: 10,
+    rewardAmount: 30,
+    cycleHours: 72,
+    autoDrawEnabled: true,
+  })
+  const [selectedDepositId, setSelectedDepositId] = useState<string | null>(null)
+  const [manualWinnerId, setManualWinnerId] = useState<string>("")
+  const [rejectionReason, setRejectionReason] = useState("")
+  const [activeTab, setActiveTab] = useState("deposits")
+
+  const activeRound = overview?.round
+  const participants = overview?.participants ?? []
+  const pendingDeposits = overview?.pendingDeposits ?? []
+  const config = overview?.config ?? settingsDraft
+
+  useEffect(() => {
+    void refreshAll()
+  }, [])
+
+  useEffect(() => {
+    if (overview?.config) {
+      setSettingsDraft(overview.config)
+    }
+  }, [overview?.config])
+
+  const refreshAll = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [overviewRes, historyRes] = await Promise.all([
+        fetch("/api/admin/blindbox/overview"),
+        fetch("/api/admin/blindbox/rounds?limit=25"),
+      ])
+      if (!overviewRes.ok) {
+        const data = await overviewRes.json().catch(() => ({}))
+        throw new Error(data.error || "Unable to load blind box overview")
+      }
+      if (!historyRes.ok) {
+        const data = await historyRes.json().catch(() => ({}))
+        throw new Error(data.error || "Unable to load round history")
+      }
+      const overviewData = await overviewRes.json()
+      const historyData = await historyRes.json()
+      setOverview(overviewData)
+      setHistory(historyData.rounds ?? [])
+    } catch (error: any) {
+      console.error("Blind box admin overview error", error)
+      toast({
+        title: "Unable to load blind box data",
+        description: error?.message ?? "Please try again later.",
+        variant: "destructive",
+      })
+    } finally {
+      setLoading(false)
+    }
+  }, [toast])
+
+  const handleApproveDeposit = useCallback(
+    async (depositId: string) => {
+      setSelectedDepositId(depositId)
+      try {
+        const response = await fetch(`/api/admin/blindbox/deposits/${depositId}/approve`, { method: "POST" })
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}))
+          throw new Error(data.error || "Unable to approve deposit")
+        }
+        toast({ title: "Deposit approved" })
+        await refreshAll()
+      } catch (error: any) {
+        console.error("Approve blind box deposit error", error)
+        toast({
+          title: "Unable to approve",
+          description: error?.message ?? "Please try again later.",
+          variant: "destructive",
+        })
+      } finally {
+        setSelectedDepositId(null)
+      }
+    },
+    [refreshAll, toast],
+  )
+
+  const handleRejectDeposit = useCallback(
+    async (depositId: string) => {
+      setSelectedDepositId(depositId)
+      try {
+        const response = await fetch(`/api/admin/blindbox/deposits/${depositId}/reject`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ reason: rejectionReason }),
+        })
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}))
+          throw new Error(data.error || "Unable to reject deposit")
+        }
+        toast({ title: "Deposit rejected" })
+        setRejectionReason("")
+        await refreshAll()
+      } catch (error: any) {
+        console.error("Reject blind box deposit error", error)
+        toast({
+          title: "Unable to reject",
+          description: error?.message ?? "Please try again later.",
+          variant: "destructive",
+        })
+      } finally {
+        setSelectedDepositId(null)
+      }
+    },
+    [refreshAll, rejectionReason, toast],
+  )
+
+  const handleDraw = useCallback(async () => {
+    if (!activeRound) {
+      toast({ title: "No active round", variant: "destructive" })
+      return
+    }
+    setLoading(true)
+    try {
+      const response = await fetch(`/api/admin/blindbox/round/${activeRound.id}/draw`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ winnerId: manualWinnerId || undefined }),
+      })
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || "Unable to finalize round")
+      }
+      toast({ title: "Round finalized", description: "A new round has been started." })
+      setManualWinnerId("")
+      await refreshAll()
+    } catch (error: any) {
+      console.error("Finalize blind box round error", error)
+      toast({
+        title: "Unable to finalize",
+        description: error?.message ?? "Please try again.",
+        variant: "destructive",
+      })
+    } finally {
+      setLoading(false)
+    }
+  }, [activeRound, manualWinnerId, refreshAll, toast])
+
+  const handleSaveSettings = useCallback(async () => {
+    setLoading(true)
+    try {
+      const response = await fetch("/api/admin/blindbox/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(settingsDraft),
+      })
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || "Unable to update settings")
+      }
+      toast({ title: "Settings updated" })
+      await refreshAll()
+    } catch (error: any) {
+      console.error("Blind box settings update error", error)
+      toast({
+        title: "Unable to save",
+        description: error?.message ?? "Please try again later.",
+        variant: "destructive",
+      })
+    } finally {
+      setLoading(false)
+    }
+  }, [refreshAll, settingsDraft, toast])
+
+  const winnerOptions = useMemo(
+    () =>
+      participants.map((participant) => ({
+        id: participant.user?.id ?? participant.id,
+        label: `${participant.user?.name ?? "Unnamed"} (${participant.hashedUserId.slice(0, 10)}...)`,
+      })),
+    [participants],
+  )
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-bold">Blind Box Management</h2>
+          <p className="text-sm text-muted-foreground">
+            Review deposits, manage participants, and control automated lucky draw rounds.
+          </p>
+        </div>
+        <Button variant="secondary" onClick={() => void refreshAll()} disabled={loading} className="gap-2">
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCcw className="h-4 w-4" />} Refresh
+        </Button>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
+        <TabsList className="grid w-full grid-cols-4">
+          <TabsTrigger value="deposits">Deposits</TabsTrigger>
+          <TabsTrigger value="participants">Participants</TabsTrigger>
+          <TabsTrigger value="control">Draw Control</TabsTrigger>
+          <TabsTrigger value="settings">Settings</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="deposits" className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <ShieldCheck className="h-5 w-5 text-emerald-500" /> Pending deposits
+              </CardTitle>
+              <CardDescription>Manually verify each deposit before participants enter the draw.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {pendingDeposits.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-muted-foreground/30 p-6 text-center text-sm text-muted-foreground">
+                  No pending deposits. Great job staying on top of reviews!
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>User</TableHead>
+                      <TableHead>TxID</TableHead>
+                      <TableHead>Amount</TableHead>
+                      <TableHead>Submitted</TableHead>
+                      <TableHead className="text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {pendingDeposits.map((deposit) => (
+                      <TableRow key={deposit.id}>
+                        <TableCell className="space-y-1">
+                          <div className="font-medium">{deposit.user?.name ?? "Unknown"}</div>
+                          <div className="text-xs text-muted-foreground">{deposit.user?.email ?? "-"}</div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="font-mono text-xs">{deposit.txId}</div>
+                        </TableCell>
+                        <TableCell>${deposit.amount.toFixed(2)}</TableCell>
+                        <TableCell className="text-xs text-muted-foreground">
+                          {new Date(deposit.createdAt).toLocaleString()}
+                        </TableCell>
+                        <TableCell className="flex justify-end gap-2">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="border-destructive/40 text-destructive"
+                            onClick={() => void handleRejectDeposit(deposit.id)}
+                            disabled={selectedDepositId === deposit.id}
+                          >
+                            Reject
+                          </Button>
+                          <Button
+                            size="sm"
+                            className="bg-emerald-500 text-white hover:bg-emerald-600"
+                            onClick={() => void handleApproveDeposit(deposit.id)}
+                            disabled={selectedDepositId === deposit.id}
+                          >
+                            {selectedDepositId === deposit.id ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              "Approve"
+                            )}
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+
+          <div className="rounded-lg border border-muted-foreground/20 bg-muted/10 p-4">
+            <Label htmlFor="rejection-reason" className="text-sm font-medium">
+              Optional rejection reason
+            </Label>
+            <Textarea
+              id="rejection-reason"
+              value={rejectionReason}
+              onChange={(event) => setRejectionReason(event.target.value)}
+              placeholder="Add a short explanation that will be sent with the rejection notification"
+              className="mt-2"
+              rows={3}
+            />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="participants" className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Users className="h-5 w-5 text-sky-500" /> Active participants
+              </CardTitle>
+              <CardDescription>
+                {participants.length} participant{participants.length === 1 ? "" : "s"} registered for the current round.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ScrollArea className="max-h-[440px] rounded-lg border border-muted-foreground/20">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>User</TableHead>
+                      <TableHead>Hash</TableHead>
+                      <TableHead>Joined</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {participants.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={3} className="py-6 text-center text-sm text-muted-foreground">
+                          No participants yet. Approve deposits to populate this list.
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      participants.map((participant) => (
+                        <TableRow key={participant.id}>
+                          <TableCell>
+                            <div className="font-medium">{participant.user?.name ?? "Unknown"}</div>
+                            <div className="text-xs text-muted-foreground">{participant.user?.email ?? "-"}</div>
+                          </TableCell>
+                          <TableCell className="font-mono text-xs">{participant.hashedUserId.slice(0, 24)}...</TableCell>
+                          <TableCell className="text-xs text-muted-foreground">
+                            {new Date(participant.joinedAt).toLocaleString()}
+                          </TableCell>
+                        </TableRow>
+                      ))
+                    )}
+                  </TableBody>
+                </Table>
+              </ScrollArea>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="control" className="space-y-6">
+          <div className="grid gap-4 lg:grid-cols-[2fr,1fr]">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Sparkles className="h-5 w-5 text-purple-500" /> Draw control panel
+                </CardTitle>
+                <CardDescription>
+                  Trigger the draw manually, or select a winner if an override is required.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-5">
+                <div className="grid gap-3">
+                  <Label htmlFor="manual-winner">Select winner (optional)</Label>
+                  <Select value={manualWinnerId} onValueChange={setManualWinnerId}>
+                    <SelectTrigger id="manual-winner" className="w-full md:w-72">
+                      <SelectValue placeholder="Let system pick randomly" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {winnerOptions.length === 0 ? (
+                        <SelectItem value="" disabled>
+                          No participants
+                        </SelectItem>
+                      ) : (
+                        winnerOptions.map((option) => (
+                          <SelectItem key={option.id} value={option.id}>
+                            {option.label}
+                          </SelectItem>
+                        ))
+                      )}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <Button
+                  onClick={() => void handleDraw()}
+                  disabled={loading || !activeRound}
+                  className="gap-2 bg-purple-600 text-white hover:bg-purple-700"
+                >
+                  {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Zap className="h-4 w-4" />} Draw winner now
+                </Button>
+                <p className="text-xs text-muted-foreground">
+                  The draw automatically runs every {config.cycleHours} hours when auto-draw is enabled. Manual draws override
+                  the countdown and immediately start a new round.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg font-semibold">Round snapshot</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm text-muted-foreground">
+                <div className="flex items-center justify-between">
+                  <span>Participants</span>
+                  <span className="font-medium text-foreground">{participants.length}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>Prize</span>
+                  <span className="font-medium text-foreground">${config.rewardAmount.toFixed(2)}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>Entry fee</span>
+                  <span className="font-medium text-foreground">${config.depositAmount.toFixed(2)}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>Auto draw</span>
+                  <Badge variant={config.autoDrawEnabled ? "default" : "secondary"}>
+                    {config.autoDrawEnabled ? "Enabled" : "Disabled"}
+                  </Badge>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold">Recent rounds</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ScrollArea className="max-h-72 rounded-lg border border-muted-foreground/20">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Ended</TableHead>
+                      <TableHead>Participants</TableHead>
+                      <TableHead>Prize</TableHead>
+                      <TableHead>Winner</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {history.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={4} className="py-6 text-center text-sm text-muted-foreground">
+                          No round history yet.
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      history.map((round) => (
+                        <TableRow key={round.id}>
+                          <TableCell className="text-xs text-muted-foreground">
+                            {new Date(round.endTime).toLocaleString()}
+                          </TableCell>
+                          <TableCell>{round.totalParticipants}</TableCell>
+                          <TableCell>${round.rewardAmount.toFixed(2)}</TableCell>
+                          <TableCell className="text-xs">
+                            {round.winnerSnapshot?.name ?? "TBD"}
+                          </TableCell>
+                        </TableRow>
+                      ))
+                    )}
+                  </TableBody>
+                </Table>
+              </ScrollArea>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="settings" className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-xl font-semibold">Draw settings</CardTitle>
+              <CardDescription>Update deposit amount, reward value, and automation preferences.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-5">
+              <div className="grid gap-4 md:grid-cols-3">
+                <div className="space-y-2">
+                  <Label htmlFor="depositAmount">Deposit amount (USD)</Label>
+                  <Input
+                    id="depositAmount"
+                    type="number"
+                    min={1}
+                    value={settingsDraft.depositAmount}
+                    onChange={(event) =>
+                      setSettingsDraft((prev) => ({ ...prev, depositAmount: Number(event.target.value) || prev.depositAmount }))
+                    }
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="rewardAmount">Reward amount (USD)</Label>
+                  <Input
+                    id="rewardAmount"
+                    type="number"
+                    min={1}
+                    value={settingsDraft.rewardAmount}
+                    onChange={(event) =>
+                      setSettingsDraft((prev) => ({ ...prev, rewardAmount: Number(event.target.value) || prev.rewardAmount }))
+                    }
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="cycleHours">Draw interval (hours)</Label>
+                  <Input
+                    id="cycleHours"
+                    type="number"
+                    min={1}
+                    value={settingsDraft.cycleHours}
+                    onChange={(event) =>
+                      setSettingsDraft((prev) => ({ ...prev, cycleHours: Number(event.target.value) || prev.cycleHours }))
+                    }
+                  />
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                <Switch
+                  id="auto-draw"
+                  checked={settingsDraft.autoDrawEnabled}
+                  onCheckedChange={(checked) =>
+                    setSettingsDraft((prev) => ({ ...prev, autoDrawEnabled: checked }))
+                  }
+                />
+                <Label htmlFor="auto-draw" className="text-sm">
+                  Enable automatic draw every {settingsDraft.cycleHours} hours
+                </Label>
+              </div>
+              <Button onClick={() => void handleSaveSettings()} disabled={loading} className="gap-2 self-start">
+                {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />} Save settings
+              </Button>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/components/blindbox/blind-box-dashboard.tsx
+++ b/components/blindbox/blind-box-dashboard.tsx
@@ -1,0 +1,548 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import Link from "next/link"
+import { AlertCircle, CheckCircle, Clock3, Crown, Loader2, RefreshCcw, Sparkle } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Separator } from "@/components/ui/separator"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useToast } from "@/components/ui/use-toast"
+
+interface BlindBoxRoundSummary {
+  id: string
+  status: "open" | "completed"
+  startTime: string
+  endTime: string
+  totalParticipants: number
+  rewardAmount: number
+  depositAmount: number
+  winnerSnapshot: {
+    name: string
+    referralCode?: string | null
+    email?: string | null
+    creditedAt?: string | null
+  } | null
+  winnerUserId: string | null
+}
+
+interface BlindBoxConfig {
+  depositAmount: number
+  rewardAmount: number
+  cycleHours: number
+  autoDrawEnabled: boolean
+}
+
+interface BlindBoxUserStatus {
+  isParticipant: boolean
+  hasPendingDeposit: boolean
+  pendingTxId: string | null
+  lastDepositStatus: "pending" | "approved" | "rejected" | null
+}
+
+interface BlindBoxHistoryRound {
+  id: string
+  startTime: string
+  endTime: string
+  status: "open" | "completed"
+  totalParticipants: number
+  rewardAmount: number
+  depositAmount: number
+  winnerUserId: string | null
+  winnerSnapshot: {
+    name: string
+    referralCode?: string | null
+    email?: string | null
+    creditedAt?: string | null
+  } | null
+}
+
+interface BlindBoxDashboardProps {
+  initialSummary: {
+    round: BlindBoxRoundSummary | null
+    previousRound: BlindBoxRoundSummary | null
+    nextDrawAt: string | null
+    participants: number
+    config: BlindBoxConfig
+    userStatus: BlindBoxUserStatus
+  }
+  constants: {
+    address: string
+    network: string
+  }
+  initialHistory: BlindBoxHistoryRound[]
+}
+
+function formatCountdown(targetIso: string | null) {
+  if (!targetIso) return "--:--:--"
+  const target = new Date(targetIso)
+  if (Number.isNaN(target.getTime())) return "--:--:--"
+
+  const diff = target.getTime() - Date.now()
+  if (diff <= 0) return "00:00:00"
+
+  const hours = Math.floor(diff / (1000 * 60 * 60))
+  const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60))
+  const seconds = Math.floor((diff % (1000 * 60)) / 1000)
+
+  return [hours, minutes, seconds].map((unit) => unit.toString().padStart(2, "0")).join(":")
+}
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(
+    amount,
+  )
+}
+
+function formatDate(value: string | null) {
+  if (!value) return "--"
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return "--"
+  return date.toLocaleString()
+}
+
+function formatName(name?: string | null) {
+  if (!name) return "Anonymous"
+  return name
+}
+
+export function BlindBoxDashboard({ initialSummary, constants, initialHistory }: BlindBoxDashboardProps) {
+  const { toast } = useToast()
+  const [summary, setSummary] = useState(initialSummary)
+  const [history, setHistory] = useState<BlindBoxHistoryRound[]>(initialHistory)
+  const [loading, setLoading] = useState(false)
+  const [countdown, setCountdown] = useState(formatCountdown(initialSummary.nextDrawAt))
+  const [isDepositOpen, setIsDepositOpen] = useState(false)
+  const [isHistoryOpen, setIsHistoryOpen] = useState(false)
+  const [txId, setTxId] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+
+  const participantCount = useMemo(() => new Intl.NumberFormat("en-US").format(summary.participants), [summary.participants])
+
+  useEffect(() => {
+    setCountdown(formatCountdown(summary.nextDrawAt))
+    if (!summary.nextDrawAt) return
+
+    const interval = window.setInterval(() => {
+      setCountdown(formatCountdown(summary.nextDrawAt))
+    }, 1000)
+
+    return () => window.clearInterval(interval)
+  }, [summary.nextDrawAt])
+
+  const reloadSummary = useCallback(async () => {
+    setLoading(true)
+    try {
+      const response = await fetch("/api/blindbox/summary")
+      if (!response.ok) {
+        throw new Error("Unable to load blind box summary")
+      }
+      const data = await response.json()
+      setSummary({
+        round: data.round,
+        previousRound: data.previousRound,
+        nextDrawAt: data.nextDrawAt,
+        participants: data.participants,
+        config: data.config,
+        userStatus: data.userStatus,
+      })
+      setCountdown(formatCountdown(data.nextDrawAt))
+    } catch (error: any) {
+      console.error("Blind box summary refresh error", error)
+      toast({ title: "Unable to refresh", description: error?.message ?? "Please try again later", variant: "destructive" })
+    } finally {
+      setLoading(false)
+    }
+  }, [toast])
+
+  const reloadHistory = useCallback(async () => {
+    try {
+      const response = await fetch("/api/blindbox/rounds?limit=10")
+      if (!response.ok) {
+        throw new Error("Unable to load winners history")
+      }
+      const data = await response.json()
+      setHistory(data.rounds ?? [])
+    } catch (error: any) {
+      console.error("Blind box history error", error)
+      toast({
+        title: "Unable to load history",
+        description: error?.message ?? "Please try again later",
+        variant: "destructive",
+      })
+    }
+  }, [toast])
+
+  const handleSubmitDeposit = useCallback(async () => {
+    const sanitized = txId.trim()
+    if (!sanitized) {
+      toast({ title: "Transaction hash required", variant: "destructive" })
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const response = await fetch("/api/blindbox/deposit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ txId: sanitized }),
+      })
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || "Unable to submit deposit")
+      }
+
+      toast({
+        title: "Deposit submitted",
+        description: "We will notify you once the transaction is verified.",
+      })
+      setTxId("")
+      setIsDepositOpen(false)
+      await reloadSummary()
+    } catch (error: any) {
+      console.error("Submit blind box deposit error", error)
+      toast({
+        title: "Unable to submit",
+        description: error?.message ?? "Please verify your transaction hash and try again.",
+        variant: "destructive",
+      })
+    } finally {
+      setSubmitting(false)
+    }
+  }, [reloadSummary, toast, txId])
+
+  const lastWinner = summary.previousRound?.winnerSnapshot
+  const nextDrawLabel = summary.nextDrawAt ? formatDate(summary.nextDrawAt) : "TBD"
+
+  const qrCodeUrl = useMemo(() => {
+    return `https://api.qrserver.com/v1/create-qr-code/?data=${encodeURIComponent(constants.address)}&size=180x180`
+  }, [constants.address])
+
+  return (
+    <div className="relative overflow-hidden rounded-3xl border border-white/5 bg-gradient-to-br from-pink-500/15 via-orange-500/10 to-yellow-500/15 p-6 shadow-xl backdrop-blur">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.4),rgba(255,255,255,0))]" />
+      <div className="absolute -top-40 right-20 h-72 w-72 rounded-full bg-orange-400/20 blur-3xl" />
+      <div className="absolute bottom-10 -left-32 h-80 w-80 rounded-full bg-pink-500/20 blur-3xl" />
+
+      <div className="relative flex flex-col gap-10">
+        <header className="text-center space-y-3">
+          <Badge variant="secondary" className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1 text-sm text-white">
+            <Sparkle className="h-4 w-4 animate-spin-slow" /> Blind Box Lucky Draw
+          </Badge>
+          <h1 className="text-4xl font-black text-white md:text-5xl">🎁 Win Exciting Rewards Every 72 Hours!</h1>
+          <p className="mx-auto max-w-2xl text-base text-white/80 md:text-lg">
+            Deposit ${summary.config.depositAmount} to join the lucky draw and get a chance to win {formatCurrency(summary.config.rewardAmount)}.
+            Each draw resets automatically every {summary.config.cycleHours} hours.
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-4 text-white/80">
+            <div className="flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-sm font-semibold">
+              <Crown className="h-4 w-4 text-yellow-200" /> Next draw in <span className="font-mono text-lg text-white">{countdown}</span>
+            </div>
+            <div className="flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-sm font-semibold">
+              <UsersIcon /> {participantCount} participants in this round
+            </div>
+            <div className="flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-sm font-semibold">
+              <Clock3 className="h-4 w-4" /> Next draw: {nextDrawLabel}
+            </div>
+          </div>
+        </header>
+
+        <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+          <Card className="relative overflow-hidden border-white/20 bg-white/10 text-white shadow-lg">
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between text-2xl font-semibold">
+                Join the current draw
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={reloadSummary}
+                  disabled={loading}
+                  className="gap-2 rounded-full bg-white/10 text-white hover:bg-white/20"
+                >
+                  {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCcw className="h-4 w-4" />} Refresh
+                </Button>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="grid gap-6">
+              <div className="grid gap-3 rounded-2xl bg-white/10 p-6">
+                <div className="flex flex-wrap items-center gap-4 text-white/90">
+                  <Badge className="bg-white/20 text-white">Entry: {formatCurrency(summary.config.depositAmount)}</Badge>
+                  <Badge className="bg-white/20 text-white">Prize: {formatCurrency(summary.config.rewardAmount)}</Badge>
+                  <Badge className="bg-white/20 text-white">Cycle: {summary.config.cycleHours}h</Badge>
+                </div>
+                <p className="text-sm text-white/80">
+                  Deposits are manually verified by our compliance team. Once approved, you&apos;ll be added to the active participant list automatically.
+                </p>
+                {summary.userStatus.hasPendingDeposit && (
+                  <div className="flex items-center gap-3 rounded-xl bg-yellow-500/20 px-4 py-3 text-sm">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Pending verification for TxID <span className="font-mono text-xs">{summary.userStatus.pendingTxId}</span>
+                  </div>
+                )}
+                {summary.userStatus.lastDepositStatus === "rejected" && !summary.userStatus.hasPendingDeposit && (
+                  <div className="flex items-center gap-3 rounded-xl bg-red-500/20 px-4 py-3 text-sm">
+                    <AlertCircle className="h-4 w-4" />
+                    Your last deposit request was rejected. Please double-check your transaction hash.
+                  </div>
+                )}
+                {summary.userStatus.isParticipant && (
+                  <div className="flex items-center gap-3 rounded-xl bg-emerald-500/20 px-4 py-3 text-sm">
+                    <CheckCircle className="h-4 w-4" /> You&apos;re in! Stay tuned for the winner announcement.
+                  </div>
+                )}
+              </div>
+
+              <div className="flex flex-wrap gap-4">
+                <Button
+                  size="lg"
+                  className="flex-1 rounded-full bg-white text-lg font-semibold text-black shadow-lg transition hover:scale-[1.01] hover:bg-white/90"
+                  onClick={() => setIsDepositOpen(true)}
+                >
+                  Deposit & Join Now
+                </Button>
+                <Button
+                  variant="outline"
+                  size="lg"
+                  className="rounded-full border-white/30 bg-white/10 text-white hover:bg-white/20"
+                  onClick={() => {
+                    setIsHistoryOpen(true)
+                    void reloadHistory()
+                  }}
+                >
+                  View Past Winners
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="grid gap-4">
+            <Card className="border-white/20 bg-white/10 text-white shadow-lg">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl font-semibold">
+                  <Crown className="h-5 w-5 text-yellow-200" /> Last Winner
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                {lastWinner ? (
+                  <>
+                    <p className="font-semibold text-white">{formatName(lastWinner.name)}</p>
+                    <p className="text-white/80">Won {formatCurrency(summary.config.rewardAmount)}</p>
+                    <p className="text-white/70 text-xs">Announced on {formatDate(lastWinner.creditedAt ?? summary.previousRound?.endTime ?? null)}</p>
+                  </>
+                ) : (
+                  <p className="text-white/70">Winner details will appear once the current round completes.</p>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card className="border-white/20 bg-white/10 text-white shadow-lg">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold">
+                  <Sparkle className="h-5 w-5 text-pink-200" /> Why Blind Box?
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm text-white/80">
+                <p>• Secure deposits verified by the admin team</p>
+                <p>• Transparent winner selection every 72 hours</p>
+                <p>• Rewards are credited instantly to your main wallet</p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        <Dialog open={isDepositOpen} onOpenChange={setIsDepositOpen}>
+          <DialogContent className="max-w-2xl border border-white/20 bg-slate-950/95 text-white">
+            <DialogHeader className="space-y-2 text-left">
+              <DialogTitle className="text-2xl font-bold">Deposit to Join the Blind Box Draw</DialogTitle>
+              <DialogDescription className="text-white/70">
+                Send exactly {formatCurrency(summary.config.depositAmount)} ({summary.config.depositAmount} USDT {constants.network}) to the address below and provide your transaction hash.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-6 md:grid-cols-[1fr,1fr]">
+              <div className="space-y-4">
+                <div className="rounded-2xl bg-white/5 p-4">
+                  <p className="text-sm text-white/70">Wallet Address</p>
+                  <p className="break-all font-mono text-sm text-white">{constants.address}</p>
+                  <div className="mt-3 flex gap-2">
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      className="rounded-full"
+                      onClick={() => {
+                        navigator.clipboard
+                          ?.writeText(constants.address)
+                          .then(() => toast({ title: "Address copied" }))
+                          .catch(() => toast({ title: "Unable to copy address", variant: "destructive" }))
+                      }}
+                    >
+                      Copy address
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="rounded-full border-white/30 text-white hover:bg-white/10"
+                      asChild
+                    >
+                      <Link
+                        href={`https://tronscan.org/#/address/${constants.address}`}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                      >
+                        View on Tronscan
+                      </Link>
+                    </Button>
+                  </div>
+                </div>
+                <div className="rounded-2xl bg-white/5 p-4 space-y-3">
+                  <label className="text-sm text-white/70">Enter your transaction hash (TxID)</label>
+                  <Input
+                    value={txId}
+                    onChange={(event) => setTxId(event.target.value)}
+                    placeholder="Paste your TxID"
+                    className="border-white/30 bg-transparent text-white placeholder:text-white/40 focus-visible:ring-white/40"
+                  />
+                </div>
+              </div>
+              <div className="flex flex-col items-center justify-center space-y-4 rounded-2xl border border-white/20 bg-white/5 p-6">
+                <img
+                  src={qrCodeUrl}
+                  alt="Deposit address QR"
+                  className="h-40 w-40 rounded-xl border border-white/10 bg-white/90 p-2 shadow-lg"
+                />
+                <p className="text-center text-xs text-white/70">
+                  Scan the QR code with a TRC20-compatible wallet to populate the address automatically. Double-check the network and amount before sending.
+                </p>
+              </div>
+            </div>
+            <DialogFooter className="flex items-center justify-between gap-4 border-t border-white/10 pt-4">
+              <div className="text-xs text-white/60">
+                Need help? Contact support with your TxID and registered email.
+              </div>
+              <div className="flex gap-3">
+                <Button
+                  variant="outline"
+                  className="rounded-full border-white/30 text-white hover:bg-white/10"
+                  onClick={() => setIsDepositOpen(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  className="rounded-full bg-white px-6 text-black hover:bg-white/90"
+                  onClick={() => void handleSubmitDeposit()}
+                  disabled={submitting}
+                >
+                  {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Submit Deposit Request"}
+                </Button>
+              </div>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        <Dialog open={isHistoryOpen} onOpenChange={setIsHistoryOpen}>
+          <DialogContent className="max-w-3xl border border-white/10 bg-slate-950/95 text-white">
+            <DialogHeader className="text-left">
+              <DialogTitle className="text-2xl font-bold">Recent Blind Box Winners</DialogTitle>
+              <DialogDescription className="text-white/70">
+                Every round is recorded for full transparency. Only approved participants are included in each draw.
+              </DialogDescription>
+            </DialogHeader>
+            <Tabs defaultValue="winners" className="space-y-4">
+              <TabsList className="rounded-full bg-white/10 text-white">
+                <TabsTrigger value="winners" className="data-[state=active]:bg-white data-[state=active]:text-black">
+                  Winners
+                </TabsTrigger>
+                <TabsTrigger value="details" className="data-[state=active]:bg-white data-[state=active]:text-black">
+                  Round details
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent value="winners" className="mt-0">
+                <ScrollArea className="max-h-80 rounded-2xl border border-white/10">
+                  <div className="divide-y divide-white/10">
+                    {history.length === 0 && (
+                      <div className="p-6 text-center text-sm text-white/70">No completed rounds yet. Check back soon!</div>
+                    )}
+                    {history.map((round) => (
+                      <div key={round.id} className="flex items-center justify-between gap-4 p-4">
+                        <div>
+                          <p className="text-sm font-semibold text-white">{formatName(round.winnerSnapshot?.name)}</p>
+                          <p className="text-xs text-white/60">Completed {formatDate(round.endTime)}</p>
+                        </div>
+                        <Badge className="rounded-full bg-white/15 text-white">{formatCurrency(round.rewardAmount)}</Badge>
+                      </div>
+                    ))}
+                  </div>
+                </ScrollArea>
+              </TabsContent>
+              <TabsContent value="details" className="mt-0">
+                <ScrollArea className="max-h-80 rounded-2xl border border-white/10">
+                  <div className="grid gap-4 p-4">
+                    {history.map((round) => (
+                      <div key={round.id} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                        <div className="flex flex-wrap items-center justify-between gap-4">
+                          <div>
+                            <p className="text-sm font-semibold text-white">Round ended {formatDate(round.endTime)}</p>
+                            <p className="text-xs text-white/60">Participants: {round.totalParticipants}</p>
+                          </div>
+                          <Badge className="rounded-full bg-white/15 text-white">
+                            Prize: {formatCurrency(round.rewardAmount)}
+                          </Badge>
+                        </div>
+                        <Separator className="my-3 bg-white/10" />
+                        <p className="text-xs text-white/70">
+                          Winner: {round.winnerSnapshot ? formatName(round.winnerSnapshot.name) : "Pending"}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </ScrollArea>
+              </TabsContent>
+            </Tabs>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </div>
+  )
+}
+
+function UsersIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      strokeWidth="1.5"
+      stroke="currentColor"
+      className="h-4 w-4"
+      fill="none"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14c-4.418 0-8 2.239-8 5v1h16v-1c0-2.761-3.582-5-8-5z"
+      />
+    </svg>
+  )
+}
+
+// extend animation utility
+const style = typeof document !== "undefined" ? document.createElement("style") : null
+if (style && !document.querySelector("#blind-box-animations")) {
+  style.id = "blind-box-animations"
+  style.innerHTML = `
+    @keyframes spin-slow { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+    .animate-spin-slow { animation: spin-slow 14s linear infinite; }
+  `
+  document.head.appendChild(style)
+}

--- a/components/layout/nav-config.ts
+++ b/components/layout/nav-config.ts
@@ -4,6 +4,7 @@ import {
   Coins,
   CreditCard,
   FileText,
+  Gift,
   HelpCircle,
   History,
   Home,
@@ -22,6 +23,7 @@ export type AppNavItem = {
 
 export const PRIMARY_NAV_ITEMS: AppNavItem[] = [
   { name: "Home", href: "/dashboard", icon: Home },
+  { name: "Blind Box", href: "/blind-box", icon: Gift },
   { name: "Mining", href: "/mining", icon: Pickaxe },
   { name: "Wallet", href: "/wallet", icon: Wallet },
   { name: "Task", href: "/tasks", icon: BarChart3 },
@@ -43,6 +45,7 @@ export const ADMIN_NAV_ITEM: AppNavItem = {
 const PAGE_TITLE_RULES: Array<{ pattern: RegExp; title: string }> = [
   { pattern: /^\/$/, title: "Welcome" },
   { pattern: /^\/dashboard(?:\/.+)?$/, title: "Dashboard" },
+  { pattern: /^\/blind-box(?:\/.+)?$/, title: "Blind Box Lucky Draw" },
   { pattern: /^\/mining(?:\/.+)?$/, title: "Mining" },
   { pattern: /^\/wallet(?:\/.+)?$/, title: "Wallet" },
   { pattern: /^\/e-wallet(?:\/.+)?$/, title: "E-Wallet" },

--- a/components/notifications/notification-bell.tsx
+++ b/components/notifications/notification-bell.tsx
@@ -104,6 +104,14 @@ export function NotificationBell() {
         return "⚠️"
       case "mining-reward":
         return "⛏️"
+      case "blindbox-submitted":
+        return "🧾"
+      case "blindbox-approved":
+        return "✅"
+      case "blindbox-rejected":
+        return "⚠️"
+      case "blindbox-won":
+        return "🎁"
       default:
         return "📢"
     }

--- a/lib/in-memory/index.ts
+++ b/lib/in-memory/index.ts
@@ -947,6 +947,7 @@ function createSettings(): InMemoryDocument[] {
       joiningBonus: { threshold: 100, pct: 5 },
       commission: { baseDirectPct: 7, startAtDeposit: 50, highTierPct: 5, highTierStartAt: 100 },
       luckyDraw: { entryFee: 10, prize: 30, cycleHours: 72, autoDrawEnabled: true },
+      blindBox: { depositAmount: 10, rewardAmount: 30, cycleHours: 72, autoDrawEnabled: true },
       createdAt: now,
       updatedAt: now,
     },

--- a/lib/services/blindbox.ts
+++ b/lib/services/blindbox.ts
@@ -1,0 +1,675 @@
+import crypto from "crypto"
+import { randomInt } from "crypto"
+
+import dbConnect from "@/lib/mongodb"
+import Balance from "@/models/Balance"
+import BlindBoxDeposit, {
+  type BlindBoxDepositStatus,
+  type IBlindBoxDeposit,
+} from "@/models/BlindBoxDeposit"
+import BlindBoxParticipant from "@/models/BlindBoxParticipant"
+import BlindBoxRound from "@/models/BlindBoxRound"
+import Notification from "@/models/Notification"
+import Settings from "@/models/Settings"
+import Transaction from "@/models/Transaction"
+import User from "@/models/User"
+
+const DEFAULT_DEPOSIT_AMOUNT = 10
+const DEFAULT_REWARD_AMOUNT = 30
+const DEFAULT_CYCLE_HOURS = 72
+const BLIND_BOX_DEPOSIT_ADDRESS = "TRhSCE8igyVmMuuRqukZEQDkn3MuEAdvfw"
+const BLIND_BOX_NETWORK = "TRC20"
+
+export type BlindBoxRoundStatus = "open" | "completed"
+
+export interface BlindBoxConfig {
+  depositAmount: number
+  rewardAmount: number
+  cycleHours: number
+  autoDrawEnabled: boolean
+}
+
+export interface BlindBoxSummaryRoundPayload {
+  id: string
+  status: BlindBoxRoundStatus
+  startTime: string
+  endTime: string
+  totalParticipants: number
+  rewardAmount: number
+  depositAmount: number
+  winnerSnapshot: {
+    name: string
+    referralCode?: string | null
+    email?: string | null
+    creditedAt?: string | null
+  } | null
+  winnerUserId: string | null
+}
+
+export interface BlindBoxSummaryResponse {
+  round: BlindBoxSummaryRoundPayload | null
+  previousRound: BlindBoxSummaryRoundPayload | null
+  nextDrawAt: string | null
+  participants: number
+  config: BlindBoxConfig
+  userStatus: {
+    isParticipant: boolean
+    hasPendingDeposit: boolean
+    pendingTxId: string | null
+    lastDepositStatus: BlindBoxDepositStatus | null
+  }
+}
+
+export class BlindBoxServiceError extends Error {
+  constructor(message: string, public status = 400) {
+    super(message)
+  }
+}
+
+async function ensureSettings(): Promise<{ config: BlindBoxConfig; settingsId: string }> {
+  await dbConnect()
+  let settings = await Settings.findOne()
+  if (!settings) {
+    settings = await Settings.create({ blindBox: defaultConfig() })
+  }
+
+  const config = normalizeConfig(settings.blindBox)
+  if (!settings.blindBox || hasConfigChanged(settings.blindBox, config)) {
+    await Settings.updateOne(
+      { _id: settings._id },
+      {
+        $set: {
+          blindBox: config,
+        },
+      },
+    )
+  }
+
+  return { config, settingsId: String(settings._id) }
+}
+
+function hasConfigChanged(existing: any, config: BlindBoxConfig) {
+  if (!existing) return true
+  return (
+    existing.depositAmount !== config.depositAmount ||
+    existing.rewardAmount !== config.rewardAmount ||
+    existing.cycleHours !== config.cycleHours ||
+    existing.autoDrawEnabled !== config.autoDrawEnabled
+  )
+}
+
+function defaultConfig(): BlindBoxConfig {
+  return {
+    depositAmount: DEFAULT_DEPOSIT_AMOUNT,
+    rewardAmount: DEFAULT_REWARD_AMOUNT,
+    cycleHours: DEFAULT_CYCLE_HOURS,
+    autoDrawEnabled: true,
+  }
+}
+
+function normalizeConfig(raw: any): BlindBoxConfig {
+  const defaults = defaultConfig()
+  if (!raw) return defaults
+
+  const depositAmount = Number(raw.depositAmount)
+  const rewardAmount = Number(raw.rewardAmount)
+  const cycleHours = Number(raw.cycleHours)
+
+  return {
+    depositAmount: Number.isFinite(depositAmount) && depositAmount > 0 ? depositAmount : defaults.depositAmount,
+    rewardAmount: Number.isFinite(rewardAmount) && rewardAmount > 0 ? rewardAmount : defaults.rewardAmount,
+    cycleHours: Number.isFinite(cycleHours) && cycleHours > 0 ? cycleHours : defaults.cycleHours,
+    autoDrawEnabled: typeof raw.autoDrawEnabled === "boolean" ? raw.autoDrawEnabled : defaults.autoDrawEnabled,
+  }
+}
+
+export async function getBlindBoxConfig(): Promise<BlindBoxConfig> {
+  const { config } = await ensureSettings()
+  return config
+}
+
+async function loadLatestCompletedRound() {
+  const [round] = await BlindBoxRound.find({ status: "completed" }).sort({ endTime: -1 }).limit(1)
+  return round ?? null
+}
+
+async function findOpenRound() {
+  const [round] = await BlindBoxRound.find({ status: "open" }).sort({ startTime: -1 }).limit(1)
+  return round ?? null
+}
+
+async function createNewRound(config: BlindBoxConfig) {
+  const now = new Date()
+  const endTime = new Date(now.getTime() + config.cycleHours * 60 * 60 * 1000)
+  const created = await BlindBoxRound.create({
+    status: "open",
+    startTime: now,
+    endTime,
+    depositAmount: config.depositAmount,
+    rewardAmount: config.rewardAmount,
+    totalParticipants: 0,
+  })
+  return BlindBoxRound.findById(created._id)
+}
+
+export async function ensureCurrentBlindBoxRound() {
+  const { config } = await ensureSettings()
+  let round = await findOpenRound()
+  const now = new Date()
+
+  if (round && round.endTime <= now && config.autoDrawEnabled) {
+    await finalizeBlindBoxRound(round._id.toString(), { trigger: "auto", startNextRound: true })
+    round = null
+  }
+
+  if (!round) {
+    round = await createNewRound(config)
+  }
+
+  return { round, config }
+}
+
+function hashUserId(userId: string) {
+  return crypto.createHash("sha256").update(userId).digest("hex")
+}
+
+export async function submitBlindBoxDeposit({
+  userId,
+  txId,
+}: {
+  userId: string
+  txId: string
+}) {
+  const { config } = await ensureSettings()
+  const sanitizedTxId = txId.trim()
+  if (!sanitizedTxId) {
+    throw new BlindBoxServiceError("Transaction hash is required", 400)
+  }
+
+  await dbConnect()
+  const existing = await BlindBoxDeposit.findOne({ txId: sanitizedTxId })
+  if (existing) {
+    throw new BlindBoxServiceError("This transaction hash has already been submitted", 409)
+  }
+
+  const deposit = await BlindBoxDeposit.create({
+    userId,
+    amount: config.depositAmount,
+    network: BLIND_BOX_NETWORK,
+    address: BLIND_BOX_DEPOSIT_ADDRESS,
+    txId: sanitizedTxId,
+    status: "pending",
+    type: "blindbox",
+  })
+
+  await Transaction.create({
+    userId,
+    type: "blindBoxDeposit",
+    amount: config.depositAmount,
+    status: "pending",
+    meta: { txId: sanitizedTxId },
+  })
+
+  await Notification.create({
+    userId,
+    title: "Blind Box deposit submitted",
+    body: "We have received your transaction hash. Our team will verify it shortly.",
+    kind: "blindbox-submitted",
+    metadata: { txId: sanitizedTxId },
+  })
+
+  return deposit
+}
+
+export async function listBlindBoxDeposits(status?: BlindBoxDepositStatus) {
+  await ensureSettings()
+  const query: Record<string, any> = {}
+  if (status) {
+    query.status = status
+  }
+
+  const deposits = await BlindBoxDeposit.find(query)
+    .sort({ createdAt: -1 })
+    .limit(200)
+    .populate("userId", "name email referralCode")
+  return deposits
+}
+
+export async function getBlindBoxParticipants(roundId: string) {
+  await ensureSettings()
+
+  const participants = await BlindBoxParticipant.find({ roundId })
+    .sort({ createdAt: -1 })
+    .populate("userId", "name email referralCode")
+
+  return participants.map((participant) => ({
+    id: participant._id.toString(),
+    user:
+      participant.userId && typeof participant.userId === "object" && "_id" in participant.userId
+        ? {
+            id: (participant.userId as any)._id.toString(),
+            name: (participant.userId as any).name ?? "",
+            email: (participant.userId as any).email ?? "",
+            referralCode: (participant.userId as any).referralCode ?? "",
+          }
+        : null,
+    joinedAt: participant.createdAt.toISOString(),
+    status: participant.status,
+    hashedUserId: participant.hashedUserId,
+  }))
+}
+
+async function addParticipantToRound(roundId: string, deposit: IBlindBoxDeposit) {
+  const hashedUserId = hashUserId(String(deposit.userId))
+  const existing = await BlindBoxParticipant.findOne({ roundId, userId: deposit.userId })
+  if (existing) {
+    return existing
+  }
+
+  const participant = await BlindBoxParticipant.create({
+    roundId,
+    userId: deposit.userId,
+    depositId: deposit._id,
+    hashedUserId,
+    status: "active",
+  })
+
+  await BlindBoxRound.updateOne({ _id: roundId }, { $inc: { totalParticipants: 1 } })
+  return participant
+}
+
+export async function approveBlindBoxDeposit({ depositId, adminId }: { depositId: string; adminId: string }) {
+  const { round } = await ensureCurrentBlindBoxRound()
+  if (!round) {
+    throw new BlindBoxServiceError("Unable to determine active round", 500)
+  }
+
+  const deposit = await BlindBoxDeposit.findById(depositId)
+  if (!deposit) {
+    throw new BlindBoxServiceError("Deposit not found", 404)
+  }
+
+  if (deposit.status !== "pending") {
+    throw new BlindBoxServiceError("Deposit has already been reviewed", 409)
+  }
+
+  await BlindBoxDeposit.updateOne(
+    { _id: deposit._id },
+    { status: "approved", reviewedAt: new Date(), reviewedBy: adminId },
+  )
+
+  await addParticipantToRound(round._id.toString(), deposit)
+
+  await Notification.create({
+    userId: deposit.userId,
+    title: "Blind Box deposit approved",
+    body: "Your deposit has been verified. You are now entered into the current Blind Box round.",
+    kind: "blindbox-approved",
+    metadata: { roundId: String(round._id), txId: deposit.txId },
+  })
+
+  await Transaction.updateMany(
+    { userId: deposit.userId, type: "blindBoxDeposit", "meta.txId": deposit.txId },
+    { $set: { status: "approved", meta: { txId: deposit.txId, roundId: String(round._id) } } },
+  )
+
+  return true
+}
+
+export async function rejectBlindBoxDeposit({
+  depositId,
+  adminId,
+  reason,
+}: {
+  depositId: string
+  adminId: string
+  reason?: string
+}) {
+  await ensureSettings()
+  const deposit = await BlindBoxDeposit.findById(depositId)
+  if (!deposit) {
+    throw new BlindBoxServiceError("Deposit not found", 404)
+  }
+
+  if (deposit.status !== "pending") {
+    throw new BlindBoxServiceError("Deposit has already been reviewed", 409)
+  }
+
+  await BlindBoxDeposit.updateOne(
+    { _id: deposit._id },
+    {
+      status: "rejected",
+      reviewedAt: new Date(),
+      reviewedBy: adminId,
+      rejectionReason: reason ?? null,
+    },
+  )
+
+  await Notification.create({
+    userId: deposit.userId,
+    title: "Blind Box deposit rejected",
+    body:
+      reason
+        ? `Your Blind Box deposit was rejected: ${reason}`
+        : "We could not verify your Blind Box deposit. Please contact support.",
+    kind: "blindbox-rejected",
+    metadata: { txId: deposit.txId },
+  })
+
+  await Transaction.updateMany(
+    { userId: deposit.userId, type: "blindBoxDeposit", "meta.txId": deposit.txId },
+    { $set: { status: "rejected", meta: { txId: deposit.txId, reason: reason ?? null } } },
+  )
+
+  return true
+}
+
+async function creditWinner(roundId: string, userId: string, rewardAmount: number, trigger: "auto" | "manual") {
+  await Balance.updateOne(
+    { userId },
+    {
+      $inc: { current: rewardAmount, totalBalance: rewardAmount, totalEarning: rewardAmount },
+    },
+  )
+
+  const tx = await Transaction.create({
+    userId,
+    type: "blindBoxReward",
+    amount: rewardAmount,
+    status: "approved",
+    meta: { roundId, trigger },
+  })
+
+  return tx
+}
+
+export async function finalizeBlindBoxRound(
+  roundId: string,
+  options: { trigger?: "auto" | "manual"; winnerId?: string | null; startNextRound?: boolean } = {},
+) {
+  const { config } = await ensureSettings()
+  const round = await BlindBoxRound.findById(roundId)
+  if (!round) {
+    throw new BlindBoxServiceError("Round not found", 404)
+  }
+
+  if (round.status === "completed") {
+    return round
+  }
+
+  const participants = await BlindBoxParticipant.find({ roundId: round._id, status: "active" })
+  let winnerParticipant = null
+
+  if (participants.length > 0) {
+    if (options.winnerId) {
+      winnerParticipant = participants.find((participant) => participant.userId.toString() === options.winnerId)
+      if (!winnerParticipant) {
+        throw new BlindBoxServiceError("Specified winner is not a participant in this round", 400)
+      }
+    } else {
+      const index = participants.length === 1 ? 0 : randomInt(participants.length)
+      winnerParticipant = participants[index]
+    }
+  }
+
+  let payoutTxId: string | null = null
+  let winnerSnapshot: BlindBoxSummaryRoundPayload["winnerSnapshot"] | null = null
+
+  if (winnerParticipant) {
+    const payoutTx = await creditWinner(round._id.toString(), winnerParticipant.userId.toString(), round.rewardAmount, options.trigger ?? "auto")
+    payoutTxId = payoutTx._id.toString()
+
+    const winnerUser = await User.findById(winnerParticipant.userId)
+    if (winnerUser) {
+      winnerSnapshot = {
+        name: winnerUser.name ?? "",
+        referralCode: winnerUser.referralCode ?? "",
+        email: winnerUser.email ?? "",
+        creditedAt: new Date().toISOString(),
+      }
+    }
+
+    await Notification.create({
+      userId: winnerParticipant.userId,
+      title: "You won the Blind Box!",
+      body: `Congratulations! You have won $${round.rewardAmount} in the Blind Box draw.`,
+      kind: "blindbox-won",
+      metadata: { roundId: String(round._id), amount: round.rewardAmount },
+    })
+  }
+
+  await BlindBoxRound.updateOne(
+    { _id: round._id },
+    {
+      status: "completed",
+      winnerUserId: winnerParticipant?.userId ?? null,
+      winnerSnapshot: winnerSnapshot
+        ? {
+            userId: winnerParticipant?.userId ?? null,
+            name: winnerSnapshot.name,
+            email: winnerSnapshot.email,
+            referralCode: winnerSnapshot.referralCode,
+            creditedAt: winnerSnapshot.creditedAt ? new Date(winnerSnapshot.creditedAt) : null,
+          }
+        : null,
+      payoutTxId,
+      endTime: new Date(),
+    },
+  )
+
+  if (options.startNextRound !== false) {
+    await createNewRound(config)
+  }
+
+  return BlindBoxRound.findById(round._id)
+}
+
+export async function getBlindBoxSummaryForUser(userId: string): Promise<BlindBoxSummaryResponse> {
+  const { round, config } = await ensureCurrentBlindBoxRound()
+  const previousRound = await loadLatestCompletedRound()
+
+  let activeParticipants = 0
+  if (round) {
+    activeParticipants = await BlindBoxParticipant.countDocuments({ roundId: round._id, status: "active" })
+  }
+
+  const [latestDeposit, participant] = await Promise.all([
+    BlindBoxDeposit.findOne({ userId }).sort({ createdAt: -1 }),
+    round ? BlindBoxParticipant.findOne({ roundId: round._id, userId }) : null,
+  ])
+
+  const pendingDeposit =
+    latestDeposit && latestDeposit.status === "pending" &&
+    (!round || latestDeposit.createdAt <= round.endTime)
+      ? latestDeposit
+      : null
+
+  return {
+    round: round
+      ? {
+          id: round._id.toString(),
+          status: round.status,
+          startTime: round.startTime.toISOString(),
+          endTime: round.endTime.toISOString(),
+          totalParticipants: activeParticipants,
+          rewardAmount: round.rewardAmount,
+          depositAmount: round.depositAmount,
+          winnerSnapshot: round.winnerSnapshot
+            ? {
+                name: round.winnerSnapshot.name,
+                referralCode: round.winnerSnapshot.referralCode ?? null,
+                email: round.winnerSnapshot.email ?? null,
+                creditedAt: round.winnerSnapshot.creditedAt
+                  ? new Date(round.winnerSnapshot.creditedAt).toISOString()
+                  : null,
+              }
+            : null,
+          winnerUserId: round.winnerUserId ? round.winnerUserId.toString() : null,
+        }
+      : null,
+    previousRound: previousRound
+      ? {
+          id: previousRound._id.toString(),
+          status: previousRound.status,
+          startTime: previousRound.startTime.toISOString(),
+          endTime: previousRound.endTime.toISOString(),
+          totalParticipants: previousRound.totalParticipants,
+          rewardAmount: previousRound.rewardAmount,
+          depositAmount: previousRound.depositAmount,
+          winnerSnapshot: previousRound.winnerSnapshot
+            ? {
+                name: previousRound.winnerSnapshot.name,
+                referralCode: previousRound.winnerSnapshot.referralCode ?? null,
+                email: previousRound.winnerSnapshot.email ?? null,
+                creditedAt: previousRound.winnerSnapshot.creditedAt
+                  ? new Date(previousRound.winnerSnapshot.creditedAt).toISOString()
+                  : null,
+              }
+            : null,
+          winnerUserId: previousRound.winnerUserId ? previousRound.winnerUserId.toString() : null,
+        }
+      : null,
+    nextDrawAt: round ? round.endTime.toISOString() : null,
+    participants: activeParticipants,
+    config,
+    userStatus: {
+      isParticipant: Boolean(participant),
+      hasPendingDeposit: Boolean(pendingDeposit),
+      pendingTxId: pendingDeposit ? pendingDeposit.txId : null,
+      lastDepositStatus: latestDeposit ? latestDeposit.status : null,
+    },
+  }
+}
+
+export async function updateBlindBoxSettings(update: Partial<BlindBoxConfig>) {
+  const { settingsId, config: current } = await ensureSettings()
+  const nextConfig: BlindBoxConfig = {
+    depositAmount: update.depositAmount && update.depositAmount > 0 ? update.depositAmount : current.depositAmount,
+    rewardAmount: update.rewardAmount && update.rewardAmount > 0 ? update.rewardAmount : current.rewardAmount,
+    cycleHours: update.cycleHours && update.cycleHours > 0 ? update.cycleHours : current.cycleHours,
+    autoDrawEnabled:
+      typeof update.autoDrawEnabled === "boolean" ? update.autoDrawEnabled : current.autoDrawEnabled,
+  }
+
+  await Settings.updateOne(
+    { _id: settingsId },
+    {
+      $set: {
+        blindBox: nextConfig,
+      },
+    },
+  )
+
+  return nextConfig
+}
+
+export async function runBlindBoxAutoDraw() {
+  const { round, config } = await ensureCurrentBlindBoxRound()
+  if (!round) return null
+
+  const now = new Date()
+  if (round.endTime <= now && config.autoDrawEnabled) {
+    return finalizeBlindBoxRound(round._id.toString(), { trigger: "auto", startNextRound: true })
+  }
+
+  return round
+}
+
+export const BLIND_BOX_CONSTANTS = {
+  address: BLIND_BOX_DEPOSIT_ADDRESS,
+  network: BLIND_BOX_NETWORK,
+}
+
+export async function listBlindBoxRounds(limit = 20) {
+  await ensureSettings()
+  const rounds = await BlindBoxRound.find({})
+    .sort({ startTime: -1 })
+    .limit(limit)
+
+  return rounds.map((round) => ({
+    id: round._id.toString(),
+    startTime: round.startTime.toISOString(),
+    endTime: round.endTime.toISOString(),
+    status: round.status,
+    totalParticipants: round.totalParticipants,
+    rewardAmount: round.rewardAmount,
+    depositAmount: round.depositAmount,
+    winnerUserId: round.winnerUserId ? round.winnerUserId.toString() : null,
+    winnerSnapshot: round.winnerSnapshot
+      ? {
+          name: round.winnerSnapshot.name,
+          referralCode: round.winnerSnapshot.referralCode ?? null,
+          email: round.winnerSnapshot.email ?? null,
+          creditedAt: round.winnerSnapshot.creditedAt
+            ? new Date(round.winnerSnapshot.creditedAt).toISOString()
+            : null,
+        }
+      : null,
+  }))
+}
+
+export async function getBlindBoxAdminSummary() {
+  const { round, config } = await ensureCurrentBlindBoxRound()
+  const previousRound = await loadLatestCompletedRound()
+
+  const [participants, pendingDeposits] = await Promise.all([
+    round ? getBlindBoxParticipants(round._id.toString()) : Promise.resolve([] as any[]),
+    BlindBoxDeposit.find({ status: "pending" })
+      .sort({ createdAt: 1 })
+      .limit(200)
+      .populate("userId", "name email referralCode"),
+  ])
+
+  const normalizedDeposits = pendingDeposits.map((deposit) => ({
+    id: deposit._id.toString(),
+    user:
+      deposit.userId && typeof deposit.userId === "object" && "_id" in deposit.userId
+        ? {
+            id: (deposit.userId as any)._id.toString(),
+            name: (deposit.userId as any).name ?? "",
+            email: (deposit.userId as any).email ?? "",
+            referralCode: (deposit.userId as any).referralCode ?? "",
+          }
+        : null,
+    txId: deposit.txId,
+    amount: deposit.amount,
+    status: deposit.status,
+    createdAt: deposit.createdAt.toISOString(),
+  }))
+
+  return {
+    round: round
+      ? {
+          id: round._id.toString(),
+          startTime: round.startTime.toISOString(),
+          endTime: round.endTime.toISOString(),
+          totalParticipants: round.totalParticipants,
+          rewardAmount: round.rewardAmount,
+          depositAmount: round.depositAmount,
+          status: round.status,
+        }
+      : null,
+    previousRound: previousRound
+      ? {
+          id: previousRound._id.toString(),
+          startTime: previousRound.startTime.toISOString(),
+          endTime: previousRound.endTime.toISOString(),
+          totalParticipants: previousRound.totalParticipants,
+          rewardAmount: previousRound.rewardAmount,
+          winnerSnapshot: previousRound.winnerSnapshot
+            ? {
+                name: previousRound.winnerSnapshot.name,
+                referralCode: previousRound.winnerSnapshot.referralCode ?? null,
+                email: previousRound.winnerSnapshot.email ?? null,
+                creditedAt: previousRound.winnerSnapshot.creditedAt
+                  ? new Date(previousRound.winnerSnapshot.creditedAt).toISOString()
+                  : null,
+              }
+            : null,
+        }
+      : null,
+    participants,
+    pendingDeposits: normalizedDeposits,
+    config,
+  }
+}

--- a/models/BlindBoxDeposit.ts
+++ b/models/BlindBoxDeposit.ts
@@ -1,0 +1,41 @@
+import mongoose, { Schema, type Document } from "mongoose"
+
+import { createModelProxy } from "@/lib/in-memory/model-factory"
+
+export type BlindBoxDepositStatus = "pending" | "approved" | "rejected"
+
+export interface IBlindBoxDeposit extends Document {
+  userId: mongoose.Types.ObjectId
+  amount: number
+  network: string
+  address: string
+  txId: string
+  status: BlindBoxDepositStatus
+  type: "blindbox"
+  createdAt: Date
+  updatedAt: Date
+  reviewedAt?: Date | null
+  reviewedBy?: mongoose.Types.ObjectId | null
+  rejectionReason?: string | null
+}
+
+const BlindBoxDepositSchema = new Schema<IBlindBoxDeposit>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
+    amount: { type: Number, required: true },
+    network: { type: String, required: true },
+    address: { type: String, required: true },
+    txId: { type: String, required: true, unique: true },
+    status: { type: String, enum: ["pending", "approved", "rejected"], default: "pending" },
+    type: { type: String, enum: ["blindbox"], default: "blindbox" },
+    reviewedAt: { type: Date, default: null },
+    reviewedBy: { type: Schema.Types.ObjectId, ref: "User", default: null },
+    rejectionReason: { type: String, default: null },
+  },
+  { timestamps: true },
+)
+
+BlindBoxDepositSchema.index({ status: 1, createdAt: -1 })
+BlindBoxDepositSchema.index({ userId: 1, createdAt: -1 })
+
+export default createModelProxy<IBlindBoxDeposit>("BlindBoxDeposit", BlindBoxDepositSchema)

--- a/models/BlindBoxParticipant.ts
+++ b/models/BlindBoxParticipant.ts
@@ -1,0 +1,31 @@
+import mongoose, { Schema, type Document } from "mongoose"
+
+import { createModelProxy } from "@/lib/in-memory/model-factory"
+
+export type BlindBoxParticipantStatus = "active" | "eliminated"
+
+export interface IBlindBoxParticipant extends Document {
+  userId: mongoose.Types.ObjectId
+  roundId: mongoose.Types.ObjectId
+  depositId: mongoose.Types.ObjectId
+  hashedUserId: string
+  status: BlindBoxParticipantStatus
+  createdAt: Date
+  updatedAt: Date
+}
+
+const BlindBoxParticipantSchema = new Schema<IBlindBoxParticipant>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
+    roundId: { type: Schema.Types.ObjectId, ref: "BlindBoxRound", required: true },
+    depositId: { type: Schema.Types.ObjectId, ref: "BlindBoxDeposit", required: true },
+    hashedUserId: { type: String, required: true },
+    status: { type: String, enum: ["active", "eliminated"], default: "active" },
+  },
+  { timestamps: true },
+)
+
+BlindBoxParticipantSchema.index({ roundId: 1, userId: 1 }, { unique: true })
+BlindBoxParticipantSchema.index({ roundId: 1, status: 1 })
+
+export default createModelProxy<IBlindBoxParticipant>("BlindBoxParticipant", BlindBoxParticipantSchema)

--- a/models/BlindBoxRound.ts
+++ b/models/BlindBoxRound.ts
@@ -1,0 +1,58 @@
+import mongoose, { Schema, type Document } from "mongoose"
+
+import { createModelProxy } from "@/lib/in-memory/model-factory"
+
+export type BlindBoxRoundStatus = "open" | "completed"
+
+export interface IBlindBoxWinnerSnapshot {
+  userId: mongoose.Types.ObjectId
+  name: string
+  email?: string | null
+  referralCode?: string | null
+  creditedAt?: Date | null
+}
+
+export interface IBlindBoxRound extends Document {
+  status: BlindBoxRoundStatus
+  startTime: Date
+  endTime: Date
+  depositAmount: number
+  rewardAmount: number
+  totalParticipants: number
+  winnerUserId?: mongoose.Types.ObjectId | null
+  winnerSnapshot?: IBlindBoxWinnerSnapshot | null
+  payoutTxId?: mongoose.Types.ObjectId | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+const BlindBoxWinnerSnapshotSchema = new Schema<IBlindBoxWinnerSnapshot>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
+    name: { type: String, required: true },
+    email: { type: String },
+    referralCode: { type: String },
+    creditedAt: { type: Date },
+  },
+  { _id: false },
+)
+
+const BlindBoxRoundSchema = new Schema<IBlindBoxRound>(
+  {
+    status: { type: String, enum: ["open", "completed"], default: "open" },
+    startTime: { type: Date, required: true },
+    endTime: { type: Date, required: true },
+    depositAmount: { type: Number, required: true },
+    rewardAmount: { type: Number, required: true },
+    totalParticipants: { type: Number, default: 0 },
+    winnerUserId: { type: Schema.Types.ObjectId, ref: "User", default: null },
+    winnerSnapshot: { type: BlindBoxWinnerSnapshotSchema, default: null },
+    payoutTxId: { type: Schema.Types.ObjectId, ref: "Transaction", default: null },
+  },
+  { timestamps: true },
+)
+
+BlindBoxRoundSchema.index({ status: 1, endTime: 1 })
+BlindBoxRoundSchema.index({ createdAt: -1 })
+
+export default createModelProxy<IBlindBoxRound>("BlindBoxRound", BlindBoxRoundSchema)

--- a/models/Notification.ts
+++ b/models/Notification.ts
@@ -14,8 +14,13 @@ export interface INotification extends Document {
     | "cap-reached"
     | "team-reward-claimed"
     | "mining-reward"
+    | "blindbox-submitted"
+    | "blindbox-approved"
+    | "blindbox-rejected"
+    | "blindbox-won"
   title: string
   body: string
+  metadata?: Record<string, any>
   read: boolean
   createdAt: Date
 }
@@ -35,11 +40,16 @@ const NotificationSchema = new Schema<INotification>(
         "cap-reached",
         "team-reward-claimed",
         "mining-reward",
+        "blindbox-submitted",
+        "blindbox-approved",
+        "blindbox-rejected",
+        "blindbox-won",
       ],
       required: true,
     },
     title: { type: String, required: true },
     body: { type: String, required: true },
+    metadata: { type: Schema.Types.Mixed, default: {} },
     read: { type: Boolean, default: false },
   },
   {

--- a/models/Settings.ts
+++ b/models/Settings.ts
@@ -31,6 +31,12 @@ export interface ISettings extends Document {
     cycleHours: number
     autoDrawEnabled: boolean
   }
+  blindBox: {
+    depositAmount: number
+    rewardAmount: number
+    cycleHours: number
+    autoDrawEnabled: boolean
+  }
 }
 
 const SettingsSchema = new Schema<ISettings>(
@@ -60,6 +66,12 @@ const SettingsSchema = new Schema<ISettings>(
     luckyDraw: {
       entryFee: { type: Number, default: 10 },
       prize: { type: Number, default: 30 },
+      cycleHours: { type: Number, default: 72 },
+      autoDrawEnabled: { type: Boolean, default: true },
+    },
+    blindBox: {
+      depositAmount: { type: Number, default: 10 },
+      rewardAmount: { type: Number, default: 30 },
       cycleHours: { type: Number, default: 72 },
       autoDrawEnabled: { type: Boolean, default: true },
     },

--- a/models/Transaction.ts
+++ b/models/Transaction.ts
@@ -16,6 +16,8 @@ export interface ITransaction extends Document {
     | "teamReward"
     | "luckyDrawEntry"
     | "luckyDrawReward"
+    | "blindBoxDeposit"
+    | "blindBoxReward"
   amount: number
   meta: any
   status?: "pending" | "approved" | "rejected"
@@ -39,6 +41,8 @@ const TransactionSchema = new Schema<ITransaction>(
         "teamReward",
         "luckyDrawEntry",
         "luckyDrawReward",
+        "blindBoxDeposit",
+        "blindBoxReward",
       ],
       required: true,
     },


### PR DESCRIPTION
## Summary
- add blind box models and backend services for deposits, participant tracking, and scheduled draws
- expose authenticated APIs and dashboard UI for joining the blind box and viewing history
- extend the admin panel with review tools, draw controls, and configurable blind box settings

## Testing
- not run (lint setup prompt blocked execution)

------
https://chatgpt.com/codex/tasks/task_e_68e57718146c832794c0f5905cdbffa1