### PR TITLE
Fix in-memory imports for Next.js build

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1,6 +1,6 @@
 import mongoose from "mongoose";
 
-import { initializeInMemoryDatabase } from "./in-memory/index.js";
+import { initializeInMemoryDatabase } from "./in-memory";
 
 const globalWithMongoose = global;
 

--- a/models/CommissionRule.js
+++ b/models/CommissionRule.js
@@ -1,6 +1,6 @@
 import mongoose from "mongoose"
 
-import { createModelProxy } from "../lib/in-memory/model-factory.js"
+import { createModelProxy } from "../lib/in-memory/model-factory"
 
 const CommissionRuleSchema = new mongoose.Schema(
   {

--- a/models/LuckyDrawEntry.js
+++ b/models/LuckyDrawEntry.js
@@ -1,6 +1,6 @@
 import mongoose from "mongoose"
 
-import { createModelProxy } from "../lib/in-memory/model-factory.js"
+import { createModelProxy } from "../lib/in-memory/model-factory"
 
 const { Schema } = mongoose
 

--- a/models/LuckyDrawRound.js
+++ b/models/LuckyDrawRound.js
@@ -1,6 +1,6 @@
 import mongoose from "mongoose"
 
-import { createModelProxy } from "../lib/in-memory/model-factory.js"
+import { createModelProxy } from "../lib/in-memory/model-factory"
 
 const { Schema } = mongoose
 

--- a/models/Settings.js
+++ b/models/Settings.js
@@ -1,6 +1,6 @@
 import mongoose from "mongoose"
 
-import { createModelProxy } from "../lib/in-memory/model-factory.js"
+import { createModelProxy } from "../lib/in-memory/model-factory"
 
 const SettingsSchema = new mongoose.Schema(
   {

--- a/models/User.js
+++ b/models/User.js
@@ -1,6 +1,6 @@
 import mongoose from "mongoose"
 
-import { createModelProxy } from "../lib/in-memory/model-factory.js"
+import { createModelProxy } from "../lib/in-memory/model-factory"
 
 const { Schema } = mongoose
 


### PR DESCRIPTION
## Summary
- update MongoDB helper to reference the existing TypeScript in-memory initializer
- point legacy JavaScript models at the shared in-memory model factory without the stale .js suffix

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5883324848327bd0ff908fd1ac3fc