### PR TITLE
Fix admin stats number serialization

### DIFF
--- a/lib/services/admin.ts
+++ b/lib/services/admin.ts
@@ -145,18 +145,16 @@ export async function getAdminInitialData(adminId: string): Promise<AdminInitial
     }
   })
 
-  const aggregateTotals = (totalsAggregate[0] as { totalDeposits: number; totalWithdrawals: number } | undefined) ?? {
-    totalDeposits: 0,
-    totalWithdrawals: 0,
-  }
+  const aggregateTotalsRaw =
+    (totalsAggregate[0] as { totalDeposits?: unknown; totalWithdrawals?: unknown } | undefined) ?? {}
 
   const stats: AdminStats = {
     totalUsers: totalUsersCount,
     activeUsers: activeUsersCount,
     pendingDeposits: pendingDepositCount,
     pendingWithdrawals: pendingWithdrawalCount,
-    totalDeposits: aggregateTotals.totalDeposits,
-    totalWithdrawals: aggregateTotals.totalWithdrawals,
+    totalDeposits: toNumber(aggregateTotalsRaw.totalDeposits),
+    totalWithdrawals: toNumber(aggregateTotalsRaw.totalWithdrawals),
   }
 
   const adminUser: AdminSessionUser = {


### PR DESCRIPTION
## Summary
- normalize admin dashboard aggregate totals to plain numbers before returning stats

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e68b8ec6a88327aa18b5771203fa8a